### PR TITLE
fix typo in visibility enum from "visibile" to "visible"

### DIFF
--- a/api/prisma/migrations/20250602164739_fix_visibility_enum_typo/migration.sql
+++ b/api/prisma/migrations/20250602164739_fix_visibility_enum_typo/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - The values [visibile] on the enum `course_visibility` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `course` MODIFY `visibility` ENUM('hidden', 'visible') NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -138,7 +138,7 @@ model logs {
 
 enum  Visibility{
   hidden
-  visibile
+  visible
 }
 
 enum RequisiteType{


### PR DESCRIPTION
Fixed typo in visibility enum:
'visibile' to 'visible'