### PR TITLE
Feature/schedule implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /client/.DS_Store
 /api/node_modules
 /api/.env
+/api/.vercel
+/api/.vercel/
+/api/.vercel/project.json
 .env
 .DS_Store
 /client/.DS_Store

--- a/Documentations/ACADEMIC_PERIOD_BOUNDARIES.md
+++ b/Documentations/ACADEMIC_PERIOD_BOUNDARIES.md
@@ -1,0 +1,311 @@
+# Academic Period Boundaries for Schedule Recurrence
+
+## Overview
+
+Schedules now respect academic period date boundaries. Events only appear on dates that fall within their associated academic period's `startAt` and `endAt` range, preventing schedules from recurring indefinitely.
+
+## The Problem We Solved
+
+**Before**: Schedules with recurring patterns (e.g., "M,W,F") would appear on **every** Monday, Wednesday, and Friday forever, regardless of semester/term boundaries.
+
+**After**: Schedules only appear within their academic period's date range, automatically stopping when the semester ends.
+
+## How It Works
+
+### 1. Date Range Validation
+
+Every time an event is checked for display, the system now validates:
+
+1. **Day of Week Match**: Does the event occur on this day (e.g., Monday)?
+2. **Academic Period Range**: Is this date within the period's start and end dates?
+
+Both conditions must be true for the event to appear.
+
+### 2. Updated Utility Function
+
+New function in `scheduleUtils.js`:
+
+```javascript
+export const isDateInPeriod = (date, periodStart, periodEnd) => {
+  if (!periodStart || !periodEnd) return true; // No restrictions
+
+  const checkDate = new Date(date);
+  const startDate = new Date(periodStart);
+  const endDate = new Date(periodEnd);
+
+  // Reset times to compare dates only
+  checkDate.setHours(0, 0, 0, 0);
+  startDate.setHours(0, 0, 0, 0);
+  endDate.setHours(0, 0, 0, 0);
+
+  return checkDate >= startDate && checkDate <= endDate;
+};
+```
+
+### 3. Integration in Filtering
+
+Both `getEventsForDate()` and `getEventsForTimeSlot()` now check period boundaries:
+
+```javascript
+export const getEventsForDate = (events, date) => {
+  const dayOfWeek = date.getDay();
+  return events.filter((event) => {
+    const occursOnDay = eventOccursOnDay(event, dayOfWeek);
+    const withinPeriod = isDateInPeriod(
+      date,
+      event.periodStart,
+      event.periodEnd
+    );
+    return occursOnDay && withinPeriod; // Both must be true
+  });
+};
+```
+
+## Required Event Properties
+
+All events must now include period date information:
+
+```javascript
+{
+  title: 'A1: Basic German Course',
+  days: 'M,W,F',              // Day recurrence pattern
+  time_start: '10:00 AM',
+  time_end: '11:00 AM',
+  color: '#FFCF00',
+  // REQUIRED for proper date boundaries
+  periodStart: '2025-09-01',  // Academic period start date
+  periodEnd: '2025-12-15',    // Academic period end date
+  periodName: 'Fall 2025',    // Optional but recommended
+}
+```
+
+## Examples
+
+### Example 1: Fall Semester Schedule
+
+```javascript
+const event = {
+  title: 'Introduction to Programming',
+  days: 'T,TH',
+  time_start: '2:00 PM',
+  time_end: '3:30 PM',
+  periodStart: '2025-09-01',
+  periodEnd: '2025-12-15',
+};
+```
+
+**Result**:
+
+- Appears on Tuesdays and Thursdays from Sept 1 to Dec 15, 2025
+- Does NOT appear on Dec 16, 2025 or later (even though it's a Tuesday)
+- Does NOT appear on Aug 28, 2025 (even though it's a Thursday)
+
+### Example 2: Spring Semester Schedule
+
+```javascript
+const event = {
+  title: 'Advanced German',
+  days: 'M,W,F',
+  time_start: '10:00 AM',
+  time_end: '11:00 AM',
+  periodStart: '2026-01-15',
+  periodEnd: '2026-05-20',
+};
+```
+
+**Result**:
+
+- Appears on M/W/F from Jan 15 to May 20, 2026
+- Completely separate from Fall semester schedules
+- Won't show on calendar views outside this date range
+
+### Example 3: Multiple Periods
+
+```javascript
+const events = [
+  {
+    title: 'German A1',
+    days: 'M,W',
+    time_start: '10:00 AM',
+    periodStart: '2025-09-01',
+    periodEnd: '2025-12-15',
+    periodName: 'Fall 2025',
+  },
+  {
+    title: 'German A1', // Same course, different period
+    days: 'M,W',
+    time_start: '10:00 AM',
+    periodStart: '2026-01-15',
+    periodEnd: '2026-05-20',
+    periodName: 'Spring 2026',
+  },
+];
+```
+
+**Result**: The same course appears in two different semesters with no overlap.
+
+## Database Integration
+
+### Prisma Query
+
+When fetching schedules from the database, **you must include the period relation**:
+
+```javascript
+const schedules = await prisma.schedule.findMany({
+  include: {
+    course: true,
+    teacher: true,
+    period: true, // REQUIRED - includes startAt and endAt
+  },
+});
+```
+
+### Transform Function
+
+The `transformScheduleToEvent()` function automatically extracts period dates:
+
+```javascript
+export const transformScheduleToEvent = (scheduleFromDB) => {
+  const [time_start, time_end] = scheduleFromDB.time
+    .split(' - ')
+    .map((t) => t.trim());
+
+  return {
+    id: scheduleFromDB.id,
+    title: scheduleFromDB.course?.name,
+    days: scheduleFromDB.days,
+    time_start,
+    time_end,
+    // Automatically extracted from period relation
+    periodStart: scheduleFromDB.period?.startAt,
+    periodEnd: scheduleFromDB.period?.endAt,
+    periodName: scheduleFromDB.period?.periodName,
+    // ... other fields
+  };
+};
+```
+
+## Edge Cases
+
+### Missing Period Dates
+
+If `periodStart` or `periodEnd` are `null` or `undefined`:
+
+```javascript
+if (!periodStart || !periodEnd) return true;
+```
+
+The event will appear on all matching days (no date restrictions). **Not recommended for production.**
+
+### Date-Only Comparison
+
+Times are reset to midnight for comparison:
+
+```javascript
+checkDate.setHours(0, 0, 0, 0);
+startDate.setHours(0, 0, 0, 0);
+endDate.setHours(0, 0, 0, 0);
+```
+
+This ensures:
+
+- Events on the start date are included
+- Events on the end date are included
+- Time of day doesn't affect date range validation
+
+### Cross-Year Periods
+
+Periods spanning multiple years work correctly:
+
+```javascript
+{
+  periodStart: '2025-11-01',
+  periodEnd: '2026-03-31',
+}
+```
+
+Events appear from November 2025 through March 2026.
+
+## Testing
+
+### Test Case 1: Event Within Period
+
+- Date: October 6, 2025 (Monday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event appears ✅
+
+### Test Case 2: Event Before Period
+
+- Date: August 25, 2025 (Monday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event does NOT appear ✅
+
+### Test Case 3: Event After Period
+
+- Date: December 22, 2025 (Monday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event does NOT appear ✅
+
+### Test Case 4: Wrong Day of Week
+
+- Date: October 7, 2025 (Tuesday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event does NOT appear ✅
+
+### Test Case 5: Period Boundary (Start Date)
+
+- Date: September 1, 2025 (Monday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event appears ✅
+
+### Test Case 6: Period Boundary (End Date)
+
+- Date: December 15, 2025 (Monday)
+- Event: M,W from Sept 1 to Dec 15
+- **Expected**: Event appears ✅
+
+## Files Modified
+
+- ✅ `/client/src/utils/scheduleUtils.js` - Added `isDateInPeriod()` function
+- ✅ `/client/src/utils/scheduleUtils.js` - Updated `getEventsForDate()` with period check
+- ✅ `/client/src/utils/scheduleUtils.js` - Updated `getEventsForTimeSlot()` with period check
+- ✅ `/client/src/utils/scheduleExamples.js` - Added period fields to transformation
+- ✅ `/client/src/utils/scheduleExamples.js` - Updated example API response
+- ✅ `/client/src/components/calendar/WeekView.js` - Updated PropTypes and default events
+- ✅ `/client/src/components/calendar/DateTile.js` - Updated PropTypes and default events
+- ✅ `/client/src/pages/admin/Schedule.js` - Added period dates to mock data
+- ✅ `/SCHEDULE_RECURRING_LOGIC.md` - Updated documentation
+- ✨ `/ACADEMIC_PERIOD_BOUNDARIES.md` - This file
+
+## Benefits
+
+1. **Automatic Semester Management**: No manual schedule cleanup needed between terms
+2. **Data Integrity**: Schedules can't accidentally appear outside their valid period
+3. **Multiple Semesters**: Same course can run in different periods without conflict
+4. **Historical Accuracy**: Past schedules remain accurate for their time period
+5. **Future Planning**: Can create schedules for future periods in advance
+
+## Important Notes
+
+⚠️ **API Requirement**: Your API endpoint **must** include the `period` relation with `startAt` and `endAt` fields.
+
+⚠️ **Date Format**: Period dates can be ISO strings or Date objects - both are handled correctly.
+
+⚠️ **Timezone**: Date comparisons use the user's local timezone. Ensure your database dates are stored in UTC and properly converted.
+
+## Migration from Old System
+
+If you have existing events without period dates:
+
+1. Add `periodStart` and `periodEnd` to all event objects
+2. Set appropriate academic period boundaries based on your calendar
+3. Test thoroughly, especially around period boundaries
+4. Update any API endpoints to include period relation
+
+## Next Steps
+
+1. Update your API endpoint to include period relation
+2. Test with real academic period data
+3. Add UI indicators showing which period is currently active
+4. Consider adding period filters to show only current/upcoming periods
+5. Add validation to prevent creating schedules outside their period range

--- a/Documentations/ACADEMIC_PERIOD_STATUS_FIX.md
+++ b/Documentations/ACADEMIC_PERIOD_STATUS_FIX.md
@@ -1,0 +1,286 @@
+# Academic Period Status Fix
+
+## Problem
+
+The academic period `status` field in the database was causing confusion because it tracks **enrollment status** (whether new enrollments are accepted), not the **actual academic period status** (whether classes are ongoing).
+
+### Previous Behavior
+
+- When an admin called "End Enrollment" for a period, the database `status` field was set to `'ended'`
+- The UI would then display the period as "Ended", implying the entire academic period (classes/semester) was over
+- This was misleading because:
+  - Classes could still be ongoing
+  - The period dates (`startAt` - `endAt`) might still be in the current date range
+  - Students and teachers would see "Ended" but classes are still happening
+
+### Example Scenario
+
+```
+Academic Period: Fall 2025
+Start Date: September 1, 2025
+End Date: December 15, 2025
+Current Date: October 15, 2025
+
+Admin clicks "End Enrollment" on October 1, 2025
+Database status = 'ended'
+
+❌ OLD: UI shows "Ended" (confusing - classes are still happening!)
+✅ NEW: UI shows "Ongoing (Enrollment Closed)" (clear and accurate)
+```
+
+## Solution
+
+The system now **separates two concepts**:
+
+1. **Period Status** - Based on dates (`startAt` and `endAt`)
+
+   - `Upcoming` - Current date is before `startAt`
+   - `Ongoing` - Current date is between `startAt` and `endAt`
+   - `Ended` - Current date is after `endAt`
+
+2. **Enrollment Status** - Based on database `status` field
+
+   - `Open` - When `status` is `'upcoming'` or `'ongoing'`
+   - `Closed` - When `status` is `'ended'`
+
+3. **Display Status** - Combines both for clarity
+   - `"Upcoming"` - Period hasn't started, enrollment open
+   - `"Upcoming (Enrollment Closed)"` - Period hasn't started, enrollment closed
+   - `"Ongoing"` - Period active, enrollment open
+   - `"Ongoing (Enrollment Closed)"` - Period active, enrollment closed ← **This fixes the confusion!**
+   - `"Ended"` - Period finished (classes done)
+
+## Changes Made
+
+### 1. Schedule Page (`client/src/pages/admin/Schedule.js`)
+
+**Lines 193-227**: Updated academic period status calculation
+
+```javascript
+// Calculate actual period status based on dates
+let periodStatus;
+if (now < startDate) {
+  periodStatus = 'Upcoming';
+} else if (now >= startDate && now <= endDate) {
+  periodStatus = 'Ongoing';
+} else {
+  periodStatus = 'Ended';
+}
+
+// Determine enrollment status
+const enrollmentOpen =
+  period.status === 'ongoing' || period.status === 'upcoming';
+
+// Display status combines both period and enrollment info
+let displayStatus;
+if (periodStatus === 'Ended') {
+  displayStatus = 'Ended';
+} else if (periodStatus === 'Ongoing') {
+  displayStatus = enrollmentOpen ? 'Ongoing' : 'Ongoing (Enrollment Closed)';
+} else {
+  // Upcoming
+  displayStatus = enrollmentOpen ? 'Upcoming' : 'Upcoming (Enrollment Closed)';
+}
+
+return {
+  ...period,
+  status: displayStatus,
+  periodStatus: periodStatus, // The actual period status
+  enrollmentOpen: enrollmentOpen, // Whether enrollment is open
+};
+```
+
+### 2. Academic Period Select Component (`client/src/components/inputs/AcademicPeriodSelect.js`)
+
+**Lines 136-152**: Updated badge colors to distinguish enrollment status
+
+```javascript
+<span
+  className={`text-xs px-2 py-1 rounded-full whitespace-nowrap ${
+    period.status === 'Ongoing'
+      ? 'bg-green-100 text-green-700' // Fully active
+      : period.status.startsWith('Ongoing')
+      ? 'bg-yellow-100 text-yellow-700' // Active but enrollment closed
+      : period.status === 'Upcoming'
+      ? 'bg-blue-100 text-blue-700' // Coming soon
+      : period.status.startsWith('Upcoming')
+      ? 'bg-orange-100 text-orange-700' // Coming but enrollment closed
+      : 'bg-gray-100 text-gray-600' // Ended
+  }`}
+>
+  {period.status}
+</span>
+```
+
+### 3. Enrollment Period Store (`client/src/stores/enrollmentPeriodStore.js`)
+
+**Lines 60-101**: Updated period status calculation with same logic
+
+### 4. Enrollment Period Utils (`client/src/utils/enrollmentPeriodUtils.js`)
+
+**Lines 67-132**: Updated `getEnrollmentPeriodStatus()` function to return both statuses
+
+```javascript
+return {
+  status, // Display status (e.g., "Ongoing (Enrollment Closed)")
+  bgColor, // CSS background color class
+  textColor, // CSS text color class
+  borderColor, // CSS border color class
+  isActive: periodStatus === 'Ongoing', // Whether period is currently active
+  periodStatus, // The actual period status (Upcoming/Ongoing/Ended)
+  enrollmentOpen, // Whether enrollment is currently open
+};
+```
+
+### 5. Enrollment Period Page (`client/src/pages/admin/EnrollmentPeriod.js`)
+
+**Lines 116-131**: Updated badge color mapping to include new statuses
+
+## Color Coding
+
+The UI now uses distinct colors to make the status immediately clear:
+
+| Status                           | Color     | Meaning                                  |
+| -------------------------------- | --------- | ---------------------------------------- |
+| **Ongoing**                      | 🟢 Green  | Period active, enrollment open           |
+| **Ongoing (Enrollment Closed)**  | 🟡 Yellow | Period active, but no new enrollments    |
+| **Upcoming**                     | 🔵 Blue   | Period hasn't started, enrollment open   |
+| **Upcoming (Enrollment Closed)** | 🟠 Orange | Period hasn't started, enrollment closed |
+| **Ended**                        | 🔴 Red    | Period finished (past end date)          |
+
+## Database Schema
+
+The database schema **remains unchanged**:
+
+```prisma
+model academic_period {
+  id            String    @id @default(cuid())
+  batchName     String
+  periodName    String
+  status        AcademicPeriodStatus @default(upcoming)  // Enrollment status
+  startAt       DateTime                                  // Period start date
+  endAt         DateTime                                  // Period end date
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  deletedAt     DateTime?
+
+  // Relations...
+}
+
+enum AcademicPeriodStatus {
+  upcoming  // Enrollment not yet open
+  ongoing   // Enrollment open
+  ended     // Enrollment closed
+}
+```
+
+**Key Point**: The `status` enum values (`upcoming`, `ongoing`, `ended`) refer to **enrollment status**, not the actual academic period dates.
+
+## API Endpoint Behavior
+
+The `endEnrollmentForPeriod()` function in the backend still sets `status: 'ended'`:
+
+```javascript
+// api/model/academic_period.js
+export const endEnrollmentForPeriod = (id) => {
+  return prisma.academic_period.update({
+    where: { id },
+    data: { status: 'ended' }, // This closes enrollment only
+  });
+};
+```
+
+This is correct! The frontend now interprets this properly:
+
+- If period dates are still active → "Ongoing (Enrollment Closed)"
+- If period dates have passed → "Ended"
+
+## Benefits
+
+1. **Clear Communication**: Users immediately understand whether classes are happening and if enrollment is open
+2. **No Database Changes**: Works with existing schema and API
+3. **Consistent Throughout App**: All components use the same logic
+4. **Admin Clarity**: Admins can see at a glance which periods accept enrollments vs which are just administratively closed
+5. **Future-Proof**: Supports scenarios like:
+   - Early enrollment closure
+   - Late-starting periods with pre-closed enrollment
+   - Historical periods that remain visible
+
+## Testing Scenarios
+
+### Scenario 1: Active Period, Enrollment Open
+
+```
+Period: Fall 2025 (Sep 1 - Dec 15)
+Current: Oct 15
+Status: ongoing
+Result: "Ongoing" (green)
+```
+
+### Scenario 2: Active Period, Enrollment Closed
+
+```
+Period: Fall 2025 (Sep 1 - Dec 15)
+Current: Oct 15
+Status: ended
+Result: "Ongoing (Enrollment Closed)" (yellow) ← THIS WAS THE BUG
+```
+
+### Scenario 3: Future Period, Enrollment Not Yet Open
+
+```
+Period: Spring 2026 (Jan 15 - May 20)
+Current: Oct 15, 2025
+Status: upcoming
+Result: "Upcoming" (blue)
+```
+
+### Scenario 4: Future Period, Enrollment Pre-Closed
+
+```
+Period: Spring 2026 (Jan 15 - May 20)
+Current: Oct 15, 2025
+Status: ended
+Result: "Upcoming (Enrollment Closed)" (orange)
+```
+
+### Scenario 5: Past Period
+
+```
+Period: Summer 2024 (Jun 1 - Aug 30)
+Current: Oct 15, 2025
+Status: ended
+Result: "Ended" (red)
+```
+
+## Related Files
+
+### Modified Files:
+
+- ✅ `client/src/pages/admin/Schedule.js`
+- ✅ `client/src/components/inputs/AcademicPeriodSelect.js`
+- ✅ `client/src/stores/enrollmentPeriodStore.js`
+- ✅ `client/src/utils/enrollmentPeriodUtils.js`
+- ✅ `client/src/pages/admin/EnrollmentPeriod.js`
+
+### Unchanged (No Changes Needed):
+
+- ✅ `api/model/academic_period.js` - Backend logic remains correct
+- ✅ `api/controller/academic_period_controller.js` - API endpoints work as intended
+- ✅ `api/prisma/schema.prisma` - Database schema unchanged
+
+## Migration Notes
+
+**No migration required!** This is purely a frontend display fix. Existing data works without modification.
+
+If you want to add explicit enrollment dates in the future, you could add optional fields:
+
+```prisma
+model academic_period {
+  // ... existing fields ...
+  enrollmentStartAt DateTime?
+  enrollmentEndAt   DateTime?
+}
+```
+
+But this is not necessary - the current solution works well.

--- a/Documentations/SCHEDULE_BACKEND_IMPLEMENTATION.md
+++ b/Documentations/SCHEDULE_BACKEND_IMPLEMENTATION.md
@@ -1,0 +1,620 @@
+# Schedule Backend Implementation
+
+## Overview
+
+Implemented a complete backend API for managing schedules with admin-only access controls. The implementation follows the existing codebase patterns and integrates seamlessly with the frontend schedule management system.
+
+## Architecture
+
+### Database Schema (Prisma)
+
+Updated the `schedule` model with additional fields to support the frontend requirements:
+
+```prisma
+model schedule {
+  id          Int       @id @default(autoincrement())
+  days        String                      // "M,W,F" or "T,TH"
+  time        String?                     // Backward compatibility
+  time_start  String?                     // "10:00 AM" or "10:00"
+  time_end    String?                     // "11:00 AM" or "11:00"
+  location    String?                     // "Online - VR1"
+  notes       String?   @db.Text         // Meeting links, additional info
+  color       String?   @default("#FFCF00") // Hex color code
+  periodStart DateTime?                   // Schedule start date
+  periodEnd   DateTime?                   // Schedule end date
+  courseId    String?
+  periodId    String?
+  teacherId   String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+
+  // Relations
+  course        course?          @relation(...)
+  period        academic_period? @relation(...)
+  teacher       users?           @relation(...)
+  userSchedules user_schedule[]
+}
+```
+
+### Migration
+
+Created migration: `20251004175654_add_schedule_fields`
+
+**Location**: `/api/prisma/migrations/20251004175654_add_schedule_fields/migration.sql`
+
+## File Structure
+
+```
+api/
+├── model/
+│   └── schedule_model.js          # Data access layer
+├── controller/
+│   └── schedule_controller.js     # Business logic layer
+├── middleware/
+│   └── scheduleValidator.js       # Validation middleware
+└── routes/
+    └── v1/
+        ├── schedule_routes.js     # Route definitions
+        └── index_routes.js        # Route registration
+```
+
+## API Endpoints
+
+All endpoints require authentication (`verifyToken` middleware).
+
+### Public Routes (Authenticated Users)
+
+#### GET /api/v1/schedules
+
+Get all schedules with related course, period, and teacher information.
+
+**Response:**
+
+```json
+[
+  {
+    "id": 1,
+    "courseId": "course_abc",
+    "courseName": "A1: Basic German Course",
+    "academicPeriodId": "period_123",
+    "academicPeriodName": "Fall 2025 - Batch A",
+    "teacherId": "teacher_456",
+    "teacherName": "Tricia Diaz",
+    "location": "Online - VR1",
+    "days": "M,W,F",
+    "time_start": "10:00 AM",
+    "time_end": "11:00 AM",
+    "periodStart": "2025-09-01",
+    "periodEnd": "2025-12-15",
+    "color": "#FFCF00",
+    "notes": "Meeting link: https://meet.google.com/xyz",
+    "createdAt": "2025-10-04T10:00:00.000Z",
+    "updatedAt": "2025-10-04T10:00:00.000Z"
+  }
+]
+```
+
+#### GET /api/v1/schedules/:id
+
+Get a single schedule by ID.
+
+**Response:** Single schedule object (same structure as above)
+
+#### GET /api/v1/schedules/period/:periodId
+
+Get all schedules for a specific academic period.
+
+#### GET /api/v1/schedules/teacher/:teacherId
+
+Get all schedules for a specific teacher.
+
+### Admin-Only Routes
+
+#### POST /api/v1/schedules
+
+Create a new schedule.
+
+**Required Middleware:**
+
+- `verifyToken` - User authentication
+- `validateUserIsAdmin` - Admin role check
+- `validateCreateSchedule` - Input validation
+- `validateTimeConstraints` - Time rules validation
+- `validateDateBoundaries` - Date range validation
+
+**Request Body:**
+
+```json
+{
+  "courseId": "course_abc",
+  "periodId": "period_123",
+  "teacherId": "teacher_456",
+  "location": "Online - VR1",
+  "days": "M,W,F",
+  "time_start": "10:00 AM",
+  "time_end": "11:00 AM",
+  "periodStart": "2025-09-01",
+  "periodEnd": "2025-12-15",
+  "color": "#FFCF00",
+  "notes": "Optional notes"
+}
+```
+
+**Validation Rules:**
+
+- All fields except `notes` are required
+- `days` must match pattern: `M,W,F` or `T,TH` (valid abbreviations: M, T, W, TH, F, S, SU)
+- `time_start` must be before `time_end`
+- Minimum duration: 30 minutes
+- Latest end time: 9:00 PM (21:00)
+- `periodStart` and `periodEnd` must be within the academic period boundaries
+- `color` must be a valid hex code (e.g., `#FFCF00`)
+
+**Response:** Created schedule object
+
+**Error Responses:**
+
+- `400` - Validation error
+- `404` - Academic period not found
+- `409` - Schedule conflict detected
+
+#### PUT /api/v1/schedules/:id
+
+Update an existing schedule.
+
+**Required Middleware:** Same as POST
+
+**Request Body:** Same as POST (all fields optional)
+
+**Response:** Updated schedule object
+
+#### DELETE /api/v1/schedules/:id
+
+Soft delete a schedule (sets `deletedAt` timestamp).
+
+**Required Middleware:**
+
+- `verifyToken`
+- `validateUserIsAdmin`
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Schedule deleted successfully"
+}
+```
+
+## Validation Rules
+
+### Time Constraints
+
+Implemented in `validateTimeConstraints` middleware:
+
+1. **Start Before End**: Start time must be before end time
+2. **Minimum Duration**: Schedule must be at least 30 minutes long
+3. **Latest End Time**: Schedule cannot end later than 9:00 PM (21:00)
+4. **Format Support**: Accepts both 12-hour (`10:00 AM`) and 24-hour (`10:00`) formats
+
+### Date Boundaries
+
+Implemented in `validateDateBoundaries` middleware:
+
+1. **Within Academic Period**: Schedule dates must fall within the academic period's start and end dates
+2. **Valid Range**: Schedule end date must be after start date
+3. **Database Verification**: Validates against actual academic period data from database
+
+### Schedule Conflicts
+
+Implemented in `checkScheduleConflicts` model function:
+
+Checks for conflicts based on:
+
+- Same teacher
+- Overlapping days (e.g., both schedules include Monday)
+- Overlapping time periods
+- Overlapping date ranges
+
+**Note:** Conflicts are detected but not enforced at the API level. The controller returns a 409 status with conflict details, allowing the frontend to handle user decisions.
+
+## Frontend Integration
+
+### Updated Files
+
+#### `/client/src/pages/admin/Schedule.js`
+
+**Changes:**
+
+1. Replaced mock data with real API calls
+2. Added error handling for API requests
+3. Implemented create, update, and delete operations
+
+**API Calls:**
+
+```javascript
+// Fetch schedules
+const response = await axiosInstance.get('/schedules');
+setSchedules(response.data);
+
+// Create schedule
+const response = await axiosInstance.post('/schedules', eventData);
+setSchedules((prev) => [...prev, response.data]);
+
+// Update schedule
+const response = await axiosInstance.put(`/schedules/${id}`, eventData);
+setSchedules((prev) => prev.map((s) => (s.id === id ? response.data : s)));
+
+// Delete schedule
+await axiosInstance.delete(`/schedules/${id}`);
+setSchedules((prev) => prev.filter((s) => s.id !== id));
+```
+
+#### `/client/src/components/modals/schedule/DateSelectModal.js`
+
+**Changes:**
+
+1. Added `useAuthStore` import
+2. Added admin check: `const { isAdmin } = useAuthStore()`
+3. Conditionally render "Add New Event" button: `{isAdmin() && <button>...}`
+
+## Security Features
+
+### Admin-Only Access
+
+All create, update, and delete operations require:
+
+1. **Authentication**: Valid JWT token in `Authorization` header
+2. **Active Status**: User account must be active
+3. **Admin Role**: User role must be `admin`
+
+Example middleware chain:
+
+```javascript
+router.post(
+  '/',
+  verifyToken, // Check valid JWT
+  validateUserIsAdmin, // Check admin role and active status
+  validateCreateSchedule, // Validate input data
+  validateTimeConstraints, // Validate time rules
+  validateDateBoundaries, // Validate date boundaries
+  createSchedule // Execute controller
+);
+```
+
+### Error Handling
+
+Comprehensive error responses:
+
+```javascript
+// Validation error
+{
+  "error": true,
+  "message": "Validation failed",
+  "details": [
+    "Course is required",
+    "Start time must be before end time"
+  ]
+}
+
+// Conflict error
+{
+  "error": true,
+  "message": "Schedule conflict detected",
+  "conflicts": [
+    {
+      "id": 5,
+      "courseName": "A2: Intermediate German",
+      "days": "M,W",
+      "time_start": "10:00 AM",
+      "time_end": "11:30 AM"
+    }
+  ]
+}
+
+// Not found error
+{
+  "error": true,
+  "message": "Schedule not found"
+}
+```
+
+## Data Transformation
+
+The backend automatically transforms data between database and frontend formats:
+
+### Database → Frontend
+
+```javascript
+// Database format
+{
+  id: 1,
+  courseId: "course_abc",
+  periodId: "period_123",
+  teacherId: "teacher_456",
+  periodStart: Date("2025-09-01T00:00:00.000Z"),
+  periodEnd: Date("2025-12-15T00:00:00.000Z"),
+  course: { name: "A1: Basic German" },
+  period: { periodName: "Fall 2025", batchName: "Batch A" },
+  teacher: { firstName: "Tricia", lastName: "Diaz" }
+}
+
+// Transformed to frontend format
+{
+  id: 1,
+  courseId: "course_abc",
+  courseName: "A1: Basic German",
+  academicPeriodId: "period_123",
+  academicPeriodName: "Fall 2025 - Batch A",
+  teacherId: "teacher_456",
+  teacherName: "Tricia Diaz",
+  periodStart: "2025-09-01",
+  periodEnd: "2025-12-15",
+  ...
+}
+```
+
+### Frontend → Database
+
+```javascript
+// Frontend sends
+{
+  periodStart: "2025-09-01",
+  periodEnd: "2025-12-15"
+}
+
+// Model converts to Date objects
+{
+  periodStart: new Date("2025-09-01"),
+  periodEnd: new Date("2025-12-15")
+}
+```
+
+## Testing
+
+### Using Postman/cURL
+
+#### 1. Login (Get JWT Token)
+
+```bash
+POST /api/v1/auth/login
+{
+  "email": "admin@example.com",
+  "password": "password123"
+}
+```
+
+#### 2. Create Schedule (Admin)
+
+```bash
+POST /api/v1/schedules
+Authorization: Bearer <jwt_token>
+{
+  "courseId": "course_abc",
+  "periodId": "period_123",
+  "teacherId": "teacher_456",
+  "location": "Online - VR1",
+  "days": "M,W,F",
+  "time_start": "10:00",
+  "time_end": "11:00",
+  "periodStart": "2025-09-01",
+  "periodEnd": "2025-12-15",
+  "color": "#FFCF00"
+}
+```
+
+#### 3. Get All Schedules
+
+```bash
+GET /api/v1/schedules
+Authorization: Bearer <jwt_token>
+```
+
+#### 4. Update Schedule (Admin)
+
+```bash
+PUT /api/v1/schedules/1
+Authorization: Bearer <jwt_token>
+{
+  "location": "Room 101",
+  "time_start": "11:00"
+}
+```
+
+#### 5. Delete Schedule (Admin)
+
+```bash
+DELETE /api/v1/schedules/1
+Authorization: Bearer <jwt_token>
+```
+
+### Testing Validation
+
+#### Invalid Time Range
+
+```json
+{
+  "time_start": "11:00",
+  "time_end": "10:00"
+}
+// Error: "Start time must be before end time"
+```
+
+#### Short Duration
+
+```json
+{
+  "time_start": "10:00",
+  "time_end": "10:15"
+}
+// Error: "Schedule duration must be at least 30 minutes"
+```
+
+#### Late End Time
+
+```json
+{
+  "time_start": "20:00",
+  "time_end": "22:00"
+}
+// Error: "Latest end time is 9:00 PM"
+```
+
+#### Outside Academic Period
+
+```json
+{
+  "periodId": "period_with_dates_2025-09-01_to_2025-12-15",
+  "periodStart": "2025-08-01",
+  "periodEnd": "2025-12-31"
+}
+// Error: "Schedule dates must be within the academic period range..."
+```
+
+## Model Functions
+
+### schedule_model.js
+
+**getAllSchedules(options)**
+
+- Get all non-deleted schedules with related data
+- Options: `includeCourse`, `includePeriod`, `includeTeacher`
+
+**getScheduleById(id)**
+
+- Get single schedule with all relations
+
+**getSchedulesByPeriod(periodId)**
+
+- Get schedules for specific academic period
+
+**getSchedulesByTeacher(teacherId)**
+
+- Get schedules for specific teacher
+
+**createSchedule(data)**
+
+- Create new schedule with date conversion
+
+**updateSchedule(id, data)**
+
+- Update existing schedule
+
+**deleteSchedule(id)**
+
+- Soft delete (sets deletedAt)
+
+**checkScheduleConflicts(scheduleData, excludeId)**
+
+- Check for teacher/time/date conflicts
+- Returns array of conflicting schedules
+
+## Best Practices
+
+### 1. Use Soft Deletes
+
+Schedules are never permanently deleted, maintaining historical data integrity.
+
+### 2. Validate at Multiple Layers
+
+- Frontend: User-friendly immediate feedback
+- Backend: Security and data integrity
+- Database: Schema constraints
+
+### 3. Transform Data Consistently
+
+Backend always returns transformed data matching frontend expectations.
+
+### 4. Handle Conflicts Gracefully
+
+Conflicts are detected and reported but don't prevent saves, allowing admin override if needed.
+
+### 5. Maintain Backward Compatibility
+
+The `time` field is kept for backward compatibility with existing data.
+
+## Future Enhancements
+
+### Potential Improvements
+
+1. **Bulk Operations**
+
+   - Create/update/delete multiple schedules at once
+   - Import schedules from CSV/Excel
+
+2. **Enhanced Conflict Detection**
+
+   - Room/location conflicts
+   - Student enrollment conflicts
+   - Automated conflict resolution suggestions
+
+3. **Notifications**
+
+   - Email notifications when schedules are created/updated
+   - Push notifications for schedule changes
+   - Calendar invites (Google Calendar, iCal)
+
+4. **Reporting**
+
+   - Teacher workload reports
+   - Room utilization reports
+   - Schedule conflict reports
+
+5. **Versioning**
+
+   - Track schedule history
+   - Revert to previous versions
+   - Audit log for all changes
+
+6. **Recurring Patterns**
+   - More complex recurrence rules
+   - Exception dates (holidays, breaks)
+   - Multiple time slots per day
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue: "No token provided"**
+
+- Ensure Authorization header is set: `Authorization: Bearer <token>`
+
+**Issue: "User is unauthorized"**
+
+- Verify user has admin role
+- Check user account is active
+
+**Issue: "Schedule dates must be within academic period range"**
+
+- Verify periodId exists
+- Ensure schedule dates fall within period's startAt and endAt
+
+**Issue: "Schedule conflict detected"**
+
+- Review conflicting schedules in response
+- Verify teacher/time/date combinations
+- Consider adjusting schedule times or dates
+
+**Issue: "Failed to create schedule"**
+
+- Check all required fields are present
+- Verify foreign keys (courseId, periodId, teacherId) exist in database
+- Review validation error details
+
+## Summary
+
+The schedule backend implementation provides:
+
+✅ Complete CRUD operations for schedules
+✅ Admin-only access control for modifications
+✅ Comprehensive validation rules matching frontend
+✅ Schedule conflict detection
+✅ Soft delete for data preservation
+✅ Data transformation for frontend compatibility
+✅ Error handling and meaningful responses
+✅ Integration with existing authentication system
+✅ Database schema updates with migration
+✅ RESTful API design following existing patterns
+
+The implementation ensures consistency with frontend requirements while maintaining security, data integrity, and scalability.

--- a/Documentations/SCHEDULE_MODAL_FLOW.md
+++ b/Documentations/SCHEDULE_MODAL_FLOW.md
@@ -1,0 +1,538 @@
+# Schedule Modal Flow Implementation
+
+## Overview
+
+Implemented a two-modal flow for creating and editing schedule events based on your design mockup:
+
+1. **Date Select Modal** - Shows all events for a selected day in a timeline view
+2. **Create/Edit Schedule Modal** - Form for creating or editing recurring schedule events
+
+## User Flow
+
+```
+Calendar View (Month/Week)
+    ↓ (Click on date/time)
+Date Select Modal
+    → Shows all events for that day
+    → Timeline view with time slots
+    ↓ (Click on event OR "Add New Event")
+Create/Edit Schedule Modal
+    → Form for event details
+    → Recurring pattern setup
+    → Save or Delete
+    ↓
+Updates Calendar → Closes modals
+```
+
+## Files Created
+
+### 1. DateSelectModal.js
+
+**Location**: `/client/src/components/modals/schedule/DateSelectModal.js`
+
+**Features**:
+
+- Shows selected date at the top
+- Timeline view with hourly time slots (6 AM - 9 PM)
+- Events displayed in their corresponding time slots
+- Color-coded events
+- "Add New Event" button at bottom
+- Click on any event to edit it
+
+**Props**:
+
+```javascript
+{
+  isOpen: Boolean,           // Control modal visibility
+  onClose: Function,         // Close modal callback
+  selectedDate: Date,        // Date to display events for
+  events: Array,             // Filtered events for this date
+  onEventClick: Function,    // Callback when event is clicked (null for new)
+}
+```
+
+### 2. CreateEditScheduleModal.js
+
+**Location**: `/client/src/components/modals/schedule/CreateEditScheduleModal.js`
+
+**Features**:
+
+- **Event Title** with color indicator
+- **Event Location** (e.g., "Online - VR1")
+- **Time** with start and end time pickers
+- **Repeat Pattern**:
+  - Days input (e.g., "M,W,F" or "T,TH")
+  - Start date and end date (academic period boundaries)
+  - Display formatted recurrence (e.g., "Every Mon, Wed, Fri until March 31, 2024")
+- **Organizer / Adviser** - Searchable dropdown of active teachers
+  - Search by teacher name or user ID
+  - Only shows active teachers from database
+  - Displays full name and ID in dropdown
+- **Color Palette** (9 color options)
+- **Notes** section (for meeting links, etc.)
+- **View Students** button (when editing)
+- **Delete Event** and **Save Event** buttons
+
+**Props**:
+
+```javascript
+{
+  isOpen: Boolean,           // Control modal visibility
+  onClose: Function,         // Close modal callback
+  event: Object,             // Event to edit (null for new)
+  selectedDate: Date,        // Pre-fill date if creating
+  onSave: Function,          // Save callback with form data
+  onDelete: Function,        // Delete callback
+  teachers: Array,           // List of active teachers
+  isLoadingTeachers: Boolean // Loading state for teachers
+}
+```
+
+## Files Created (Continued)
+
+### 3. TeacherSelect.js
+
+**Location**: `/client/src/components/inputs/TeacherSelect.js`
+
+**Features**:
+
+- Searchable dropdown component for teacher selection
+- Real-time search/filter by name or user ID
+- Shows teacher's full name and ID
+- Displays email in dropdown for reference
+- Click outside to close dropdown
+- Loading state support
+- Highlights selected teacher
+
+**Props**:
+
+```javascript
+{
+  value: String,             // Selected teacher ID
+  onChange: Function,        // Callback with full teacher object
+  teachers: Array,           // List of teachers
+  isLoading: Boolean         // Loading state
+}
+```
+
+## Files Modified
+
+### 4. Schedule.js
+
+**Location**: `/client/src/pages/admin/Schedule.js`
+
+**Added State Management**:
+
+```javascript
+// Modal states
+const [showDateSelectModal, setShowDateSelectModal] = useState(false);
+const [showCreateEditModal, setShowCreateEditModal] = useState(false);
+const [selectedDate, setSelectedDate] = useState(null);
+const [selectedEvent, setSelectedEvent] = useState(null);
+const [eventsForSelectedDate, setEventsForSelectedDate] = useState([]);
+
+// Teacher data
+const [teachers, setTeachers] = useState([]);
+const [isLoadingTeachers, setIsLoadingTeachers] = useState(false);
+```
+
+**Added Data Fetching**:
+
+- Fetches active teachers from API on component mount
+- Filters for teachers with `status: 'active'` and `role: 'teacher'`
+- Mock data provided for testing
+
+**Added Handlers**:
+
+- `handleDateTimeClick` - Opens DateSelectModal
+- `handleEventClick` - Opens CreateEditModal
+- `handleSaveEvent` - Saves/updates event
+- `handleDeleteEvent` - Deletes event
+- `handleCloseModals` - Closes both modals
+
+### 5. Calendar.js
+
+**Location**: `/client/src/components/calendar/Calendar.js`
+
+**Changes**:
+
+- Destructured props to extract `events` and `onDateTimeClick`
+- Passes `onDateClick` to DateTile components
+- Passes `onTimeSlotClick` to WeekView component
+
+### 6. DateTile.js
+
+**Location**: `/client/src/components/calendar/DateTile.js`
+
+**Changes**:
+
+- Added `onDateClick` prop
+- Added `handleClick` function
+- Passes date and filtered events when clicked
+- Updated PropTypes
+
+### 7. WeekView.js
+
+**Location**: `/client/src/components/calendar/WeekView.js`
+
+**Changes**:
+
+- Added `onTimeSlotClick` prop
+- Click handler on time slot cells
+- Passes date and events for that time slot
+- Updated PropTypes
+
+## Data Flow
+
+### 1. User Clicks on Date/Time
+
+```javascript
+// In Calendar -> DateTile or WeekView
+onClick={() => {
+  const currentDate = new Date(year, month, day);
+  const filteredEvents = getEventsForDate(events, currentDate);
+  onDateClick(currentDate, filteredEvents);
+}}
+```
+
+### 2. DateSelectModal Opens
+
+```javascript
+// In Schedule.js
+const handleDateTimeClick = (date, eventsForDate) => {
+  setSelectedDate(date);
+  setEventsForSelectedDate(eventsForDate);
+  setShowDateSelectModal(true);
+};
+```
+
+### 3. User Clicks Event or "Add New"
+
+```javascript
+// In DateSelectModal
+const handleEventClick = (event) => {
+  setSelectedEvent(event); // null if adding new
+  setShowDateSelectModal(false);
+  setShowCreateEditModal(true);
+};
+```
+
+### 4. User Saves Event
+
+```javascript
+// In Schedule.js
+const handleSaveEvent = (eventData) => {
+  if (selectedEvent) {
+    // Update existing event
+    setSchedules((prev) =>
+      prev.map((schedule) =>
+        schedule.id === selectedEvent.id
+          ? { ...schedule, ...eventData }
+          : schedule
+      )
+    );
+  } else {
+    // Create new event
+    const newEvent = { ...eventData, id: Date.now() };
+    setSchedules((prev) => [...prev, newEvent]);
+  }
+
+  // Close modal and reset state
+  setShowCreateEditModal(false);
+  setSelectedEvent(null);
+};
+```
+
+## Event Data Structure
+
+Based on the recurring schedule logic with academic period boundaries:
+
+```javascript
+{
+  // Required fields
+  title: 'A1: Basic German Course',
+  days: 'M,W,F',              // Day recurrence pattern
+  time_start: '10:00 AM',
+  time_end: '11:00 AM',
+  color: '#FFCF00',
+
+  // Academic period boundaries
+  periodStart: '2025-09-01',  // Events only appear from this date
+  periodEnd: '2025-12-15',    // Events only appear until this date
+  periodName: 'Fall 2025',
+
+  // Optional fields
+  location: 'Online - VR1',
+  teacherId: 'teacher_456',   // Teacher's database ID
+  teacherName: 'Tricia D. Diaz',  // Teacher's full name
+  notes: 'Meeting link: https://meet.google.com/xyz',
+  id: 123,                    // From database
+  courseId: 'course_abc',
+  periodId: 'period_123',
+}
+```
+
+## Styling Details
+
+### Date Select Modal
+
+- Max width: `max-w-2xl`
+- Max height: `max-h-[90vh]`
+- Time slots displayed vertically
+- Events colored with their assigned colors
+- Hover effects on event items
+
+### Create/Edit Modal
+
+- Max width: `max-w-4xl`
+- Max height: `max-h-[90vh]`
+- 3-column grid (2 columns form, 1 column notes/color)
+- Responsive: stacks to 1 column on mobile
+- Color palette with 9 options
+- Form fields with icons from react-icons
+
+## Integration with API
+
+### Fetching Active Teachers
+
+```javascript
+// In Schedule.js useEffect
+fetch('/api/v1/users?role=teacher&status=active')
+  .then((res) => res.json())
+  .then((data) => {
+    // Filter for active teachers only
+    const activeTeachers = data.filter(
+      (user) => user.role === 'teacher' && user.status === 'active'
+    );
+    setTeachers(activeTeachers);
+  })
+  .catch((error) => {
+    console.error('Error fetching teachers:', error);
+    setTeachers([]);
+  })
+  .finally(() => setIsLoadingTeachers(false));
+```
+
+**Expected Teacher Data Structure:**
+
+```javascript
+{
+  id: 'cuid_or_uuid',
+  userId: 'TCH-001',        // User ID for searching
+  firstName: 'Tricia',
+  lastName: 'Diaz',
+  email: 'tricia.diaz@example.com',
+  status: 'active',         // IMPORTANT: Only 'active' teachers shown
+  role: 'teacher',
+  phoneNumber: '+1234567890',
+  // ... other user fields
+}
+```
+
+### Fetching Schedules
+
+```javascript
+// In Schedule.js useEffect
+fetch('/api/v1/schedules?include=period,course,teacher')
+  .then((res) => res.json())
+  .then((data) => {
+    const events = data.schedules.map((schedule) =>
+      transformScheduleToEvent(schedule)
+    );
+    setSchedules(events);
+  })
+  .finally(() => setIsLoading(false));
+```
+
+### Saving Event
+
+```javascript
+// In handleSaveEvent
+fetch('/api/v1/schedules', {
+  method: selectedEvent ? 'PUT' : 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    ...eventData,
+    // Transform time format if needed
+    time: `${eventData.time_start} - ${eventData.time_end}`,
+  }),
+})
+  .then((res) => res.json())
+  .then((savedEvent) => {
+    // Update local state with saved event
+    setSchedules((prev) => [...prev, transformScheduleToEvent(savedEvent)]);
+  });
+```
+
+### Deleting Event
+
+```javascript
+// In handleDeleteEvent
+fetch(`/api/v1/schedules/${event.id}`, {
+  method: 'DELETE',
+}).then(() => {
+  setSchedules((prev) => prev.filter((s) => s.id !== event.id));
+});
+```
+
+## Usage Example
+
+```javascript
+import React, { useState } from 'react';
+import Schedule from './pages/admin/Schedule';
+
+function App() {
+  return (
+    <div className="App">
+      <Schedule />
+    </div>
+  );
+}
+```
+
+The Schedule page handles everything internally:
+
+1. Renders the Calendar component
+2. Manages both modals
+3. Handles all click events
+4. Manages state for create/edit operations
+
+## Features Implemented
+
+✅ Click on any date in Month view → Opens DateSelectModal
+✅ Click on any time slot in Week view → Opens DateSelectModal
+✅ DateSelectModal shows all events for selected date
+✅ Timeline view with hourly slots
+✅ Click on event in DateSelectModal → Opens CreateEditModal (edit mode)
+✅ Click "Add New Event" → Opens CreateEditModal (create mode)
+✅ CreateEditModal form with all fields from design
+✅ Color palette selection
+✅ Recurring pattern input with date range
+✅ **Organizer / Adviser searchable dropdown**
+
+- Fetches active teachers from database
+- Search by name or user ID
+- Displays teacher info with email
+- Only shows active teachers
+  ✅ Save button creates/updates event
+  ✅ Delete button removes event (with confirmation)
+  ✅ Close buttons on both modals
+  ✅ Academic period boundary validation
+  ✅ Responsive design
+
+## API Endpoints Required
+
+### Teachers Endpoint
+
+```
+GET /api/v1/users?role=teacher&status=active
+```
+
+**Response:**
+
+```json
+[
+  {
+    "id": "cuid_123",
+    "userId": "TCH-001",
+    "firstName": "Tricia",
+    "lastName": "Diaz",
+    "email": "tricia.diaz@example.com",
+    "status": "active",
+    "role": "teacher"
+  }
+]
+```
+
+### Schedules Endpoint
+
+```
+GET /api/v1/schedules?include=period,course,teacher
+POST /api/v1/schedules
+PUT /api/v1/schedules/:id
+DELETE /api/v1/schedules/:id
+```
+
+## Next Steps
+
+1. **API Integration**:
+
+   - Replace mock teacher data with actual API call
+   - Connect schedule CRUD operations to backend
+   - Handle loading states during API calls
+   - Add error handling and user feedback
+
+2. **Validation**:
+
+   - Add form validation for required fields
+   - Validate date ranges (end date after start date)
+   - Validate time ranges (end time after start time)
+   - Validate day patterns (e.g., "M,W,F" format)
+
+3. **Enhanced Features**:
+
+   - Add "View Students" functionality
+   - Implement course/teacher selection dropdowns
+   - Add conflict detection (overlapping schedules)
+   - Add bulk operations (duplicate, delete multiple)
+   - Add search/filter in DateSelectModal
+
+4. **UI Enhancements**:
+
+   - Add animations for modal transitions
+   - Add loading spinners within modals
+   - Add success/error toast notifications
+   - Add keyboard shortcuts (ESC to close, etc.)
+
+5. **Mobile Optimization**:
+   - Optimize form layout for mobile devices
+   - Add swipe gestures for time navigation
+   - Improve touch targets for small screens
+
+## Testing Checklist
+
+### Basic Functionality
+
+- [ ] Click on date in month view opens DateSelectModal
+- [ ] Click on time slot in week view opens DateSelectModal
+- [ ] DateSelectModal shows correct events for selected date
+- [ ] Click on event opens CreateEditModal with pre-filled data
+- [ ] Click "Add New Event" opens CreateEditModal with empty form
+- [ ] Save new event adds it to calendar
+- [ ] Save edited event updates calendar
+- [ ] Delete event removes it from calendar (with confirmation)
+- [ ] Close buttons work on both modals
+
+### Teacher Selection
+
+- [ ] Teacher dropdown loads active teachers only
+- [ ] Search by teacher name filters correctly
+- [ ] Search by teacher ID filters correctly
+- [ ] Selected teacher appears in input field
+- [ ] Teacher data persists when editing event
+- [ ] Dropdown closes when clicking outside
+- [ ] Loading state shows while fetching teachers
+
+### Form Features
+
+- [ ] Form validation prevents invalid submissions
+- [ ] Color palette selection updates color indicator
+- [ ] Recurring pattern displays correctly
+- [ ] Academic period dates are respected
+- [ ] All form fields save correctly
+
+### UI/UX
+
+- [ ] Responsive design works on mobile
+- [ ] Dropdowns scroll properly with many items
+- [ ] Search is case-insensitive
+- [ ] Icons display correctly
+
+## Notes
+
+- All modals use `position: fixed` with full-screen overlay
+- Z-index set to 50 to appear above calendar
+- Event colors must be hex codes (e.g., `#FFCF00`)
+- Day patterns use abbreviations: SU, M, T, W, TH, F, S
+- Time format can be 12-hour (10:00 AM) or 24-hour (10:00)
+- Academic period dates should be ISO format (YYYY-MM-DD)

--- a/Documentations/SCHEDULE_RECURRING_LOGIC.md
+++ b/Documentations/SCHEDULE_RECURRING_LOGIC.md
@@ -1,0 +1,299 @@
+# Recurring Schedule Logic Implementation
+
+## Overview
+
+The calendar system has been updated to work with **recurring schedule patterns** instead of requiring separate event entries for each date. Events are now defined once with a `days` field (e.g., "M,W,F") and will automatically appear on all matching days of the week.
+
+## Changes Made
+
+### 1. **New Utility File: `scheduleUtils.js`**
+
+Location: `/client/src/utils/scheduleUtils.js`
+
+Contains reusable functions for handling recurring schedules:
+
+- `dayAbbreviationMap` - Maps day abbreviations to JavaScript day indices
+- `eventOccursOnDay()` - Checks if an event occurs on a specific day of week
+- `getEventsForDate()` - Filters events for a specific date
+- `parseTime()` - Parses time strings to hour/minute objects
+- `getEventsForTimeSlot()` - Gets events for a specific time slot and date
+
+### 2. **Updated Components**
+
+#### WeekView Component
+
+- Removed hardcoded date fields from events
+- Now uses `days` field to determine which days events occur
+- Automatically shows events on matching days of the week
+- Uses utility functions from `scheduleUtils.js`
+
+#### DateTile Component
+
+- Added `month` and `year` props to calculate correct dates
+- Filters events based on day-of-week recurrence pattern
+- Uses utility functions from `scheduleUtils.js`
+
+#### Calendar Component
+
+- Updated to pass `month` and `year` props to DateTile components
+- Ready to accept events with recurring patterns
+
+### 3. **Example Files**
+
+#### scheduleExamples.js
+
+Location: `/client/src/utils/scheduleExamples.js`
+
+Provides:
+
+- `transformScheduleToEvent()` - Converts database schedule to calendar event format
+- `generateColorForCourse()` - Generates consistent colors for courses
+- Example API response structure
+- Example transformed events
+
+#### Schedule.js (Admin Page)
+
+Location: `/client/src/pages/admin/Schedule.js`
+
+Includes:
+
+- Example recurring schedule events
+- Documentation on how to integrate with API
+- Ready-to-use event data structure
+
+## Data Structure
+
+### Event Object Format
+
+```javascript
+{
+  title: 'A1: Basic German Course',
+  days: 'M,W,F',              // Recurring days (comma-separated)
+  time_start: '10:00 AM',     // Start time
+  time_end: '11:00 AM',       // End time (optional)
+  color: '#FFCF00',           // Display color
+  // Academic period date range - REQUIRED for proper recurrence
+  periodStart: '2025-09-01',  // Academic period start date
+  periodEnd: '2025-12-15',    // Academic period end date
+  periodName: 'Fall 2025',    // Period name (optional)
+  // Optional fields from database:
+  id: 1,
+  courseId: 'course_123',
+  periodId: 'period_456',
+  teacherId: 'teacher_789',
+}
+```
+
+### Important: Academic Period Boundaries
+
+**Schedules only appear within their academic period date range.**
+
+- Events with `periodStart: '2025-09-01'` and `periodEnd: '2025-12-15'` will **only** show on dates between September 1 and December 15, 2025
+- Outside this range, the events will not appear, even if the day of week matches
+- This ensures schedules don't continue indefinitely and respect semester/term boundaries
+- If `periodStart` and `periodEnd` are omitted, events will appear on all matching days (not recommended for production)
+
+### Day Abbreviations
+
+The following abbreviations are supported:
+
+- `SU` = Sunday
+- `M` = Monday
+- `T` = Tuesday
+- `W` = Wednesday
+- `TH` = Thursday
+- `F` = Friday
+- `S` = Saturday
+
+**Multiple days:** Use comma-separated values (e.g., `"M,W,F"` or `"T,TH"`)
+
+## Prisma Schema Alignment
+
+The implementation matches your Prisma schema:
+
+```prisma
+model schedule {
+  id        Int      @id @default(autoincrement())
+  days      String   // "M,W,F" or "T,TH" format
+  time      String   // "10:00 AM - 11:00 AM" format
+  courseId  String?
+  periodId  String?
+  teacherId String?
+  // ... relations
+}
+```
+
+## Usage Example
+
+### Basic Usage
+
+```javascript
+import Calendar from '../../components/calendar/Calendar';
+
+function MySchedulePage() {
+  const events = [
+    {
+      title: 'A1: Basic German Course',
+      days: 'M,W', // Shows on Mondays and Wednesdays
+      time_start: '10:00 AM',
+      time_end: '11:00 AM',
+      color: '#FFCF00',
+      periodStart: '2025-09-01', // Only appears Sept 1 onwards
+      periodEnd: '2025-12-15', // Only appears until Dec 15
+      periodName: 'Fall 2025',
+    },
+  ];
+
+  return <Calendar events={events} />;
+}
+```
+
+### With API Integration
+
+```javascript
+import { useState, useEffect } from 'react';
+import Calendar from '../../components/calendar/Calendar';
+import { transformScheduleToEvent } from '../../utils/scheduleExamples';
+
+function MySchedulePage() {
+  const [schedules, setSchedules] = useState([]);
+
+  useEffect(() => {
+    // Fetch from your API - IMPORTANT: Include period relation
+    // Example: /api/v1/schedules?include=period,course,teacher
+    fetch('/api/v1/schedules')
+      .then((res) => res.json())
+      .then((data) => {
+        // Transform database format to calendar format
+        // transformScheduleToEvent automatically extracts periodStart/periodEnd
+        const events = data.schedules.map((schedule) =>
+          transformScheduleToEvent(schedule)
+        );
+        setSchedules(events);
+      });
+  }, []);
+
+  return <Calendar events={schedules} />;
+}
+```
+
+**Important**: Your API endpoint must include the `period` relation to get `startAt` and `endAt` dates. Without these dates, events may not display correctly.
+
+## Benefits
+
+1. **No Date Duplication**: Define a schedule once, it appears on all matching days
+2. **Schema Alignment**: Works directly with your Prisma `schedule` model
+3. **Efficient Storage**: Store recurring patterns instead of individual dates
+4. **Easy Updates**: Change one record to update all occurrences
+5. **Flexible Patterns**: Support any combination of days (M, T, W, TH, F, S, SU)
+
+## Migration Notes
+
+### Before (Old Approach)
+
+```javascript
+// Required separate entries for each date
+{
+  title: 'Course',
+  date: new Date(2025, 9, 6),  // Monday
+  time_start: '10:00 AM',
+},
+{
+  title: 'Course',
+  date: new Date(2025, 9, 8),  // Wednesday
+  time_start: '10:00 AM',
+}
+```
+
+### After (New Approach)
+
+```javascript
+// Single entry covers all Mondays and Wednesdays
+{
+  title: 'Course',
+  days: 'M,W',  // Recurs every Monday and Wednesday
+  time_start: '10:00 AM',
+}
+```
+
+## Testing
+
+The default events in the components demonstrate the recurring logic:
+
+1. Navigate to the Schedule page
+2. **Initial Load**: Observe the loading spinner while data is being fetched (1 second simulated delay)
+3. **View Switching**: Click Month/Week buttons to see the transition spinner (300ms)
+4. **Event Display**: Switch between Month and Week views to see events appearing on correct days
+5. **Recurring Pattern**: Events with `days: 'M,W'` appear only on Mondays and Wednesdays
+
+### Using the Spinner Component
+
+The spinner can be used anywhere in your app:
+
+```javascript
+import Spinner from '../components/common/Spinner';
+
+// Small spinner
+<Spinner size="sm" />
+
+// Medium spinner with message
+<Spinner size="md" message="Loading..." />
+
+// Large spinner with custom color
+<Spinner size="lg" color="text-blue-500" message="Please wait..." />
+
+// Extra large spinner
+<Spinner size="xl" color="text-dark-red-2" message="Loading schedule data..." />
+```
+
+## Next Steps
+
+1. **Create API Endpoint**: Fetch schedules from your database
+2. **Implement Transform Function**: Use `transformScheduleToEvent()` or create your own
+3. **Add Loading States**: Show loading indicators while fetching data
+4. **Error Handling**: Handle API errors gracefully
+5. **Filtering**: Add filters by period, course, or teacher
+6. **CRUD Operations**: Add create/edit/delete functionality for schedules
+
+## Loading States
+
+The calendar system includes loading spinners for a better user experience:
+
+### View Switching Spinner
+
+When switching between Month and Week views:
+
+- Shows a loading spinner during the transition
+- Disables view buttons to prevent multiple clicks
+- Smooth 300ms transition delay
+
+### Data Fetching Spinner
+
+When loading schedule data from the API:
+
+- Full-screen spinner with "Loading schedule data..." message
+- Displayed until data is fetched and processed
+- Graceful error handling support
+
+### Spinner Component
+
+Reusable spinner component located at `/client/src/components/common/Spinner.js`:
+
+- Configurable sizes: `sm`, `md`, `lg`, `xl`
+- Customizable colors
+- Optional loading message
+- SVG-based with CSS animations
+
+## Files Modified
+
+- ✅ `/client/src/components/calendar/WeekView.js`
+- ✅ `/client/src/components/calendar/DateTile.js`
+- ✅ `/client/src/components/calendar/Calendar.js` - Added view switching spinner
+- ✅ `/client/src/pages/admin/Schedule.js` - Added data fetching spinner
+
+## Files Created
+
+- ✨ `/client/src/utils/scheduleUtils.js`
+- ✨ `/client/src/utils/scheduleExamples.js`
+- ✨ `/client/src/components/common/Spinner.js` - Reusable spinner component
+- ✨ `/SCHEDULE_RECURRING_LOGIC.md` (this file)

--- a/Documentations/SPINNER_INTEGRATION_SUMMARY.md
+++ b/Documentations/SPINNER_INTEGRATION_SUMMARY.md
@@ -1,0 +1,209 @@
+# Spinner Integration Summary
+
+## Overview
+
+Successfully integrated loading spinners into the calendar system for improved user experience during view switching and data fetching operations.
+
+## Changes Made
+
+### 1. Created Reusable Spinner Component
+
+**File**: `/client/src/components/common/Spinner.js`
+
+A flexible, reusable spinner component with:
+
+- **4 size options**: `sm`, `md`, `lg`, `xl`
+- **Customizable colors**: Uses Tailwind CSS classes
+- **Optional messages**: Display loading text below spinner
+- **SVG-based animation**: Smooth, performant spinning effect
+- **PropTypes validation**: Type-safe props
+
+### 2. Updated Calendar Component
+
+**File**: `/client/src/components/calendar/Calendar.js`
+
+**Features Added**:
+
+- `isLoadingView` state to track view switching
+- `handleViewChange()` function with 300ms transition delay
+- Spinner display during view transitions
+- Disabled buttons during loading to prevent multiple clicks
+- Visual feedback with opacity changes on disabled state
+- Minimum height set on calendar container for consistent layout
+
+**User Experience**:
+
+- Smooth transition when switching between Month and Week views
+- Clear visual indication that something is happening
+- Prevents accidental double-clicks during transitions
+
+### 3. Updated Schedule Page
+
+**File**: `/client/src/pages/admin/Schedule.js`
+
+**Features Added**:
+
+- `isLoading` state for data fetching
+- `useEffect` hook to simulate API data fetching
+- Full-screen spinner during initial data load
+- 1-second simulated delay (ready for real API integration)
+- Comprehensive comments for API integration
+
+**User Experience**:
+
+- Shows large spinner with "Loading schedule data..." message
+- Prevents rendering calendar until data is ready
+- Clean, centered loading state
+
+## Spinner Usage Examples
+
+### Basic Usage
+
+```javascript
+import Spinner from '../components/common/Spinner';
+
+// Default medium spinner
+<Spinner />;
+```
+
+### With Custom Size and Message
+
+```javascript
+<Spinner size="lg" message="Loading schedules..." />
+```
+
+### With Custom Color
+
+```javascript
+<Spinner size="xl" color="text-blue-500" message="Please wait..." />
+```
+
+### In a Container
+
+```javascript
+<div className="flex justify-center items-center min-h-screen">
+  <Spinner size="lg" color="text-dark-red-2" message="Loading data..." />
+</div>
+```
+
+## Integration Points
+
+### View Switching Flow
+
+1. User clicks Month or Week button
+2. `handleViewChange()` is called
+3. `isLoadingView` set to `true`
+4. Buttons disabled, spinner shown
+5. After 300ms, view changes
+6. `isLoadingView` set to `false`
+7. New view rendered
+
+### Data Fetching Flow
+
+1. Component mounts
+2. `useEffect` triggers
+3. `isLoading` set to `true`
+4. Full-screen spinner displayed
+5. API call made (or simulated)
+6. Data received and processed
+7. `isLoading` set to `false`
+8. Calendar rendered with data
+
+## API Integration Guide
+
+Replace the simulated data fetch in `Schedule.js`:
+
+```javascript
+// Remove this simulation
+setTimeout(() => {
+  const mockSchedules = [...];
+  setSchedules(mockSchedules);
+  setIsLoading(false);
+}, 1000);
+
+// Replace with actual API call
+fetch('/api/v1/schedules')
+  .then(res => res.json())
+  .then(data => {
+    const events = data.schedules.map(schedule =>
+      transformScheduleToEvent(schedule)
+    );
+    setSchedules(events);
+  })
+  .catch(error => {
+    console.error('Error fetching schedules:', error);
+    setSchedules([]); // Set empty array on error
+    // Optionally show error message to user
+  })
+  .finally(() => {
+    setIsLoading(false);
+  });
+```
+
+## Benefits
+
+### User Experience
+
+- ✅ Clear feedback during async operations
+- ✅ Prevents confusion when switching views
+- ✅ Professional, polished feel
+- ✅ Reduces perceived loading time
+
+### Developer Experience
+
+- ✅ Reusable component for entire app
+- ✅ Easy to integrate into any component
+- ✅ Consistent loading states across app
+- ✅ Simple API with sensible defaults
+
+### Performance
+
+- ✅ Lightweight SVG spinner
+- ✅ CSS-based animations (GPU accelerated)
+- ✅ No external dependencies
+- ✅ Minimal re-renders
+
+## Testing Checklist
+
+- [x] Spinner appears when switching from Month to Week view
+- [x] Spinner appears when switching from Week to Month view
+- [x] Buttons are disabled during view transition
+- [x] Full-screen spinner shows on initial page load
+- [x] Calendar renders correctly after loading
+- [x] No console errors
+- [x] No linting errors
+- [x] Responsive on mobile devices
+- [x] Spinner is centered and visible
+- [x] Messages display correctly
+
+## Future Enhancements
+
+1. **Error States**: Add error spinner variant with red color
+2. **Progress Indicators**: Add percentage-based loading bars
+3. **Skeleton Loading**: Replace spinner with skeleton screens
+4. **Retry Logic**: Add retry button for failed data fetches
+5. **Caching**: Cache fetched data to reduce spinner frequency
+6. **Optimistic Updates**: Show data immediately with stale-while-revalidate pattern
+
+## Files Summary
+
+### Modified
+
+- `/client/src/components/calendar/Calendar.js` - Added view switching spinner
+- `/client/src/pages/admin/Schedule.js` - Added data fetching spinner
+
+### Created
+
+- `/client/src/components/common/Spinner.js` - New reusable spinner component
+
+### Updated Documentation
+
+- `/SCHEDULE_RECURRING_LOGIC.md` - Added loading states section
+- `/SPINNER_INTEGRATION_SUMMARY.md` - This file
+
+## Notes
+
+- Spinner uses the same design pattern as existing spinners in the codebase
+- Colors match the app's theme (`text-dark-red-2`)
+- Transition delays are optimized for perceived performance
+- Component follows React best practices and PropTypes validation

--- a/Documentations/TEACHER_SELECT_FEATURE.md
+++ b/Documentations/TEACHER_SELECT_FEATURE.md
@@ -1,0 +1,416 @@
+# Teacher Select Feature - Implementation Summary
+
+## Overview
+
+Enhanced the Schedule Modal with a searchable teacher dropdown for the "Organizer / Adviser" field. The component fetches active teachers from the database and allows searching by name or user ID.
+
+## Changes Made
+
+### 1. New Component: TeacherSelect
+
+**File**: `/client/src/components/inputs/TeacherSelect.js`
+
+A reusable searchable dropdown component for selecting teachers.
+
+**Key Features**:
+
+- 🔍 **Real-time Search**: Filter by teacher name or user ID
+- 👥 **Active Teachers Only**: Only displays teachers with `status: 'active'`
+- 📧 **Detailed Display**: Shows full name, user ID, and email
+- 🎯 **Click Outside to Close**: Dropdown closes when clicking outside
+- ⏳ **Loading State**: Shows loading message while fetching data
+- ✨ **Highlight Selection**: Selected teacher is highlighted
+- 📱 **Responsive**: Scrollable dropdown for many teachers
+
+**Component Interface**:
+
+```javascript
+<TeacherSelect
+  value={teacherId} // Selected teacher's ID
+  onChange={handleSelect} // Callback with full teacher object
+  teachers={teachers} // Array of teacher objects
+  isLoading={isLoadingTeachers} // Loading state
+/>
+```
+
+### 2. Updated CreateEditScheduleModal
+
+**File**: `/client/src/components/modals/schedule/CreateEditScheduleModal.js`
+
+**Changes**:
+
+- Changed label from "Organizer" to **"Organizer / Adviser"**
+- Replaced text input with `TeacherSelect` component
+- Updated form data structure:
+  - `organizer` (text) → `teacherId` (ID) + `teacherName` (display)
+- Added `handleTeacherSelect()` to process teacher selection
+- Added new props: `teachers` and `isLoadingTeachers`
+- Updated PropTypes to match new structure
+
+### 3. Updated Schedule.js
+
+**File**: `/client/src/pages/admin/Schedule.js`
+
+**New State**:
+
+```javascript
+const [teachers, setTeachers] = useState([]);
+const [isLoadingTeachers, setIsLoadingTeachers] = useState(false);
+```
+
+**New useEffect Hook**:
+
+- Fetches teachers on component mount
+- Filters for `role: 'teacher'` and `status: 'active'`
+- Includes mock data for testing (replace with real API)
+- Passes teachers to CreateEditScheduleModal
+
+## Data Flow
+
+### 1. Fetch Teachers
+
+```javascript
+// On component mount
+fetch('/api/v1/users?role=teacher&status=active')
+  → Filter active teachers
+  → setTeachers(activeTeachers)
+```
+
+### 2. User Selects Teacher
+
+```javascript
+// In TeacherSelect component
+User types search term
+  → Filter teachers by name/ID
+  → Display filtered list
+  → User clicks teacher
+  → onChange(teacherObject) called
+```
+
+### 3. Save Teacher Selection
+
+```javascript
+// In CreateEditScheduleModal
+handleTeacherSelect(teacher)
+  → setFormData({
+      teacherId: teacher.id,
+      teacherName: `${teacher.firstName} ${teacher.lastName}`
+    })
+  → Data saved when form submitted
+```
+
+## API Integration
+
+### Expected Teacher Data Structure
+
+From your Prisma schema (`users` model):
+
+```javascript
+{
+  id: "cuid_abc123",          // Primary key
+  userId: "TCH-001",          // User ID for display/search
+  firstName: "Tricia",
+  lastName: "Diaz",
+  email: "tricia.diaz@example.com",
+  phoneNumber: "+1234567890",
+  status: "active",           // IMPORTANT: Only 'active' shown
+  role: "teacher",            // IMPORTANT: Only 'teacher' shown
+  profilePicLink: "...",
+  createdAt: "2024-01-15T10:00:00Z",
+  // ... other fields
+}
+```
+
+### API Endpoint Required
+
+```
+GET /api/v1/users?role=teacher&status=active
+```
+
+**Query Parameters**:
+
+- `role=teacher` - Filter by teacher role
+- `status=active` - Only active users
+
+**Response Format**:
+
+```json
+{
+  "success": true,
+  "teachers": [
+    {
+      "id": "cuid_123",
+      "userId": "TCH-001",
+      "firstName": "Tricia",
+      "lastName": "Diaz",
+      "email": "tricia.diaz@example.com",
+      "status": "active",
+      "role": "teacher"
+    }
+  ]
+}
+```
+
+### Updating Schedule.js for Real API
+
+Replace the mock data in `Schedule.js`:
+
+```javascript
+// Remove this mock data block
+setTimeout(() => {
+  const mockTeachers = [...];
+  setTeachers(mockTeachers);
+  setIsLoadingTeachers(false);
+}, 500);
+
+// Replace with real API call
+fetch('/api/v1/users?role=teacher&status=active')
+  .then(res => res.json())
+  .then(data => {
+    // Adjust based on your API response structure
+    const activeTeachers = data.teachers || data;
+    setTeachers(activeTeachers);
+  })
+  .catch(error => {
+    console.error('Error fetching teachers:', error);
+    setTeachers([]);
+  })
+  .finally(() => setIsLoadingTeachers(false));
+```
+
+## Search Functionality
+
+### Search Algorithm
+
+The component searches through:
+
+1. **Full Name**: `firstName + lastName` (case-insensitive)
+2. **User ID**: `userId` field (case-insensitive)
+
+```javascript
+const filteredTeachers = teachers.filter((teacher) => {
+  const searchLower = searchTerm.toLowerCase();
+  const fullName = `${teacher.firstName} ${teacher.lastName}`.toLowerCase();
+  const userId = teacher.userId?.toLowerCase() || '';
+
+  return fullName.includes(searchLower) || userId.includes(searchLower);
+});
+```
+
+### Search Examples
+
+| Search Term | Matches                         |
+| ----------- | ------------------------------- |
+| "tricia"    | Tricia Diaz                     |
+| "TCH-001"   | Teacher with ID TCH-001         |
+| "diaz"      | Any teacher with "Diaz" in name |
+| "john"      | John Smith                      |
+
+## UI/UX Features
+
+### Dropdown Display
+
+Each teacher item shows:
+
+```
+┌────────────────────────────────────┐
+│ Tricia Diaz                    ◄ Name (bold)
+│ ID: TCH-001 • tricia@example.com  ◄ ID and email (gray)
+└────────────────────────────────────┘
+```
+
+### States
+
+1. **Empty State** (no teachers):
+
+   ```
+   No teachers found
+   ```
+
+2. **Loading State**:
+
+   ```
+   Loading teachers...
+   ```
+
+3. **Search Results**:
+
+   - Real-time filtering as user types
+   - Case-insensitive matching
+   - Highlights selected teacher
+
+4. **Selected State**:
+   - Selected teacher's name shown in input
+   - Highlighted in dropdown with red background
+
+### Accessibility
+
+- ✅ Keyboard navigation (auto-focus on search)
+- ✅ Click outside to close
+- ✅ Clear visual feedback for selection
+- ✅ Loading states
+- ✅ Error handling
+
+## Integration Checklist
+
+### Backend Requirements
+
+- [ ] Create/verify API endpoint: `GET /api/v1/users`
+- [ ] Support query parameters: `?role=teacher&status=active`
+- [ ] Return teacher data in expected format
+- [ ] Include necessary fields: id, userId, firstName, lastName, email, status, role
+
+### Frontend Tasks
+
+- [x] Create TeacherSelect component
+- [x] Update CreateEditScheduleModal
+- [x] Update Schedule.js with teacher fetching
+- [x] Add loading states
+- [ ] Replace mock data with real API call
+- [ ] Add error handling/retry logic
+- [ ] Test with real data
+
+### Testing
+
+- [ ] Verify only active teachers appear
+- [ ] Test search by full name
+- [ ] Test search by user ID
+- [ ] Test with empty search
+- [ ] Test with no results
+- [ ] Test loading state
+- [ ] Test dropdown scroll with many items
+- [ ] Test click outside to close
+- [ ] Test on mobile devices
+
+## Example Usage
+
+### Creating New Schedule with Teacher
+
+1. User clicks on date in calendar
+2. DateSelectModal opens
+3. User clicks "Add New Event"
+4. CreateEditScheduleModal opens
+5. User fills in event details
+6. User clicks "Organizer / Adviser" dropdown
+7. Dropdown shows active teachers
+8. User searches "TCH-001" or "Tricia"
+9. User selects "Tricia Diaz"
+10. Selected teacher appears in field
+11. User clicks "Save Event"
+12. Event saved with:
+    ```javascript
+    {
+      ...eventData,
+      teacherId: "cuid_123",
+      teacherName: "Tricia Diaz"
+    }
+    ```
+
+### Editing Schedule with Existing Teacher
+
+1. Event has existing teacher: `teacherId: "cuid_123"`
+2. Modal opens with pre-filled data
+3. Dropdown shows "Tricia Diaz" as selected
+4. User can search and select different teacher
+5. Save updates teacherId and teacherName
+
+## Database Schema Alignment
+
+Aligns with your Prisma schema:
+
+```prisma
+model users {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  firstName String
+  lastName  String
+  email     String   @unique
+  status    String?  // "active", "inactive", etc.
+  role      String?  @default("student")  // "teacher", "admin", etc.
+
+  teacherSchedules schedule[] @relation("TeacherSchedules")
+  // ... other fields
+}
+
+model schedule {
+  id        Int      @id @default(autoincrement())
+  teacherId String?
+  teacher   users?   @relation("TeacherSchedules", fields: [teacherId], references: [id])
+  // ... other fields
+}
+```
+
+## Benefits
+
+1. **Better UX**: Searchable dropdown vs free text input
+2. **Data Validation**: Only valid teachers can be selected
+3. **Consistent Data**: Teacher IDs stored correctly
+4. **Active Teachers Only**: Prevents assigning inactive teachers
+5. **Search Functionality**: Find teachers quickly
+6. **Display Rich Info**: See email and ID while selecting
+7. **Reusable Component**: Can be used elsewhere in app
+
+## Troubleshooting
+
+### Teachers Not Loading
+
+Check:
+
+1. API endpoint is correct: `/api/v1/users?role=teacher&status=active`
+2. API returns proper response format
+3. CORS configured if frontend/backend on different domains
+4. Authentication headers included if required
+
+### Search Not Working
+
+Check:
+
+1. Teacher objects have `userId`, `firstName`, `lastName` fields
+2. Fields are strings (not null/undefined)
+3. Search is case-insensitive
+
+### Selected Teacher Not Persisting
+
+Check:
+
+1. `teacherId` is being saved in form data
+2. `teacherId` matches the `id` field from teacher object
+3. Teacher still exists and is active when editing
+
+## Next Steps
+
+1. **Implement Backend Endpoint**:
+
+   - Create route handler for GET `/api/v1/users`
+   - Add query parameter filtering
+   - Include status and role filters
+   - Return paginated results if needed
+
+2. **Test with Real Data**:
+
+   - Replace mock teachers with API call
+   - Test with production database
+   - Verify performance with many teachers
+
+3. **Enhance Features** (Optional):
+
+   - Add teacher avatars
+   - Add pagination for large lists
+   - Add "Recently Used" teachers section
+   - Add keyboard shortcuts (arrow keys, enter)
+   - Add teacher details tooltip on hover
+
+4. **Error Handling**:
+   - Show error message if API fails
+   - Add retry button
+   - Graceful fallback to text input
+
+## Files Modified Summary
+
+- ✨ **Created**: `/client/src/components/inputs/TeacherSelect.js` (147 lines)
+- ✏️ **Modified**: `/client/src/components/modals/schedule/CreateEditScheduleModal.js`
+- ✏️ **Modified**: `/client/src/pages/admin/Schedule.js`
+- 📝 **Updated**: `/SCHEDULE_MODAL_FLOW.md`
+- 📄 **Created**: `/TEACHER_SELECT_FEATURE.md` (this file)
+
+All linting checks passed! ✅

--- a/Documentations/TOKEN_VALIDATION_FIX.md
+++ b/Documentations/TOKEN_VALIDATION_FIX.md
@@ -1,0 +1,344 @@
+# Token Validation and Session Management Fix
+
+## Problem
+
+When navigating directly to protected routes (e.g., `/admin/schedule`) with an expired JWT token, the application did not redirect to the login page. Users could see protected pages even though their session had expired.
+
+### Root Cause
+
+The application relied on the `isAuthenticated` flag stored in localStorage, which persisted even after the JWT token expired. Token validation only occurred when API requests were made, not when routes were accessed directly.
+
+## Solution
+
+Implemented a comprehensive token validation system with three layers of protection:
+
+### 1. App-Level Token Validation
+
+**File**: `/client/src/App.js`
+
+**Changes**:
+
+```javascript
+// Added useEffect hook to validate token on app load
+const { isAuthenticated, validateToken } = useAuthStore();
+
+useEffect(() => {
+  if (isAuthenticated) {
+    validateToken();
+  }
+}, [isAuthenticated, validateToken]);
+```
+
+**Behavior**:
+
+- Validates token whenever the app initializes
+- Checks token validity when `isAuthenticated` state changes
+- Automatically logs out users with expired tokens before rendering protected routes
+
+### 2. Auth Store Validation Method
+
+**File**: `/client/src/stores/authStore.js`
+
+**Added Method**:
+
+```javascript
+validateToken: async () => {
+  const token = getCookieItem('token');
+
+  if (!token) {
+    get().logout();
+    return false;
+  }
+
+  try {
+    // Make a lightweight API call to validate the token
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/users`);
+
+    if (response.status === 200) {
+      return true;
+    }
+  } catch (error) {
+    // If token is expired or invalid, logout
+    if (
+      error.response &&
+      (error.response.status === 401 || error.response.status === 403)
+    ) {
+      console.log('Token validation failed, logging out...');
+      get().logout();
+      return false;
+    }
+    return true;
+  }
+};
+```
+
+**Behavior**:
+
+- Makes a lightweight API call to verify token validity
+- Uses the `/users` endpoint which requires authentication
+- Automatically logs out users with invalid/expired tokens
+- Handles network errors gracefully
+
+### 3. Enhanced Axios Response Interceptor
+
+**File**: `/client/src/utils/axios.js`
+
+**Improvements**:
+
+```javascript
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // Handle 401 unauthorized or 403 forbidden errors
+    if (
+      error.response &&
+      (error.response.status === 401 || error.response.status === 403)
+    ) {
+      const errorMessage = error.response.data?.message || '';
+
+      // Check if it's a token-related error
+      const isTokenError =
+        errorMessage.toLowerCase().includes('token') ||
+        errorMessage.toLowerCase().includes('unauthorized') ||
+        errorMessage.toLowerCase().includes('expired') ||
+        errorMessage.toLowerCase().includes('login');
+
+      // Only logout for token-related errors
+      if (isTokenError || error.response.status === 401) {
+        const { logout, isAuthenticated } = useAuthStore.getState();
+
+        if (isAuthenticated) {
+          logout();
+          Swal.fire({
+            title: 'Session Expired',
+            text: 'Your session has expired. Please login again.',
+            icon: 'warning',
+            confirmButtonColor: '#DE0000',
+          }).then(() => {
+            window.location.href = '/login';
+          });
+        }
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+```
+
+**Improvements**:
+
+- Now catches all 401 (Unauthorized) errors
+- Distinguishes between token errors and permission errors (403)
+- Shows user-friendly "Session Expired" message
+- Automatically redirects to login page after dismissing alert
+- Prevents unnecessary logouts for non-token-related 403 errors
+
+## How It Works
+
+### Scenario 1: Direct Route Access with Expired Token
+
+1. User navigates directly to `/admin/schedule`
+2. App loads and `useEffect` runs
+3. `validateToken()` is called
+4. API request to `/users` fails with 401
+5. User is logged out automatically
+6. `isAuthenticated` becomes `false`
+7. React Router redirects to `/login` (due to routing logic in App.js)
+
+### Scenario 2: Making API Request with Expired Token
+
+1. User is on a protected page
+2. Makes an API request (e.g., fetching schedules)
+3. Request fails with 401 error
+4. Axios interceptor catches the error
+5. Shows "Session Expired" alert
+6. Logs out user
+7. Redirects to `/login`
+
+### Scenario 3: Valid Token
+
+1. User navigates to protected route
+2. `validateToken()` is called
+3. API request succeeds (200 OK)
+4. User remains authenticated
+5. Route renders normally
+
+## Benefits
+
+### Security
+
+✅ Prevents access to protected routes with expired tokens
+✅ Validates tokens before rendering sensitive pages
+✅ Automatic logout on token expiration
+✅ Distinguishes between authentication and authorization errors
+
+### User Experience
+
+✅ Clear "Session Expired" message
+✅ Automatic redirect to login
+✅ No confusing error states
+✅ Seamless re-authentication flow
+
+### Developer Experience
+
+✅ Centralized token validation logic
+✅ Consistent error handling across the app
+✅ Easy to debug with console logs
+✅ Follows existing codebase patterns
+
+## Testing
+
+### Test Case 1: Expired Token on Direct Route Access
+
+**Steps**:
+
+1. Login to the application
+2. Wait for token to expire (or manually delete/invalidate token in cookies)
+3. Directly navigate to `/admin/schedule` in browser address bar
+
+**Expected Result**:
+
+- User is automatically redirected to `/login`
+- No protected content is displayed
+- Console shows "Token validation failed, logging out..."
+
+### Test Case 2: Expired Token During API Request
+
+**Steps**:
+
+1. Login to the application
+2. Navigate to `/admin/schedule`
+3. Wait for token to expire
+4. Try to create/edit a schedule (triggers API request)
+
+**Expected Result**:
+
+- Alert shows "Session Expired"
+- User is logged out
+- Redirect to `/login` after dismissing alert
+
+### Test Case 3: Valid Token
+
+**Steps**:
+
+1. Login to the application
+2. Navigate to `/admin/schedule`
+
+**Expected Result**:
+
+- Page loads normally
+- No logout occurs
+- All API requests work as expected
+
+### Test Case 4: Permission Error (Non-Token 403)
+
+**Steps**:
+
+1. Login as a student
+2. Try to create a schedule (admin-only action)
+
+**Expected Result**:
+
+- Shows permission error from API
+- Does NOT log out user
+- User remains on current page
+
+## Configuration
+
+No additional configuration is required. The fix uses existing:
+
+- JWT token storage in cookies
+- Auth store for state management
+- Axios instance for API calls
+- React Router for navigation
+
+## Performance Impact
+
+**Minimal**: Only one additional API call (`GET /users`) on app initialization when user is authenticated. This is a lightweight endpoint and the call is async, not blocking the UI.
+
+## Future Enhancements
+
+### Token Refresh
+
+Implement automatic token refresh before expiration:
+
+```javascript
+// In validateToken method
+if (tokenWillExpireSoon()) {
+  await refreshToken();
+}
+```
+
+### Silent Validation
+
+Add periodic background token validation:
+
+```javascript
+// Check token validity every 5 minutes
+setInterval(() => {
+  if (isAuthenticated) {
+    validateToken();
+  }
+}, 5 * 60 * 1000);
+```
+
+### Better Error Messages
+
+Differentiate between:
+
+- Token expired
+- Token invalid
+- Token missing
+- Server unreachable
+
+### Token Expiry Warning
+
+Warn users before token expires:
+
+```javascript
+if (tokenExpiresIn < 5 minutes) {
+  showWarning("Your session will expire soon");
+}
+```
+
+## Rollback Plan
+
+If issues arise, revert these three files:
+
+1. `/client/src/App.js` - Remove `useEffect` and `validateToken` import
+2. `/client/src/stores/authStore.js` - Remove `validateToken` method
+3. `/client/src/utils/axios.js` - Revert to simple 401 error handling
+
+The application will still work, but won't prevent direct route access with expired tokens.
+
+## Related Files
+
+**Modified**:
+
+- `/client/src/App.js`
+- `/client/src/stores/authStore.js`
+- `/client/src/utils/axios.js`
+
+**Unchanged** (but related):
+
+- `/client/src/utils/jwt.js` - Cookie management
+- `/client/src/utils/auth.js` - Auth utilities
+- `/api/middleware/authValidator.js` - Backend token validation
+
+## Summary
+
+This fix ensures that expired tokens are detected and handled properly at three critical points:
+
+1. **App initialization** - Validates before rendering any routes
+2. **API requests** - Catches expired tokens in responses
+3. **Route changes** - Validates when authentication state changes
+
+The implementation is:
+
+- ✅ Secure
+- ✅ User-friendly
+- ✅ Developer-friendly
+- ✅ Performant
+- ✅ Consistent with existing codebase patterns
+
+Users can no longer access protected routes with expired tokens, regardless of how they navigate to those routes.

--- a/api/controller/schedule_controller.js
+++ b/api/controller/schedule_controller.js
@@ -1,0 +1,330 @@
+import * as ScheduleModel from '../model/schedule_model.js';
+
+/**
+ * Get all schedules
+ * Returns schedules with course, period, and teacher information
+ */
+export const getSchedules = async (req, res) => {
+  try {
+    const schedules = await ScheduleModel.getAllSchedules({
+      includeCourse: true,
+      includePeriod: true,
+      includeTeacher: true,
+    });
+
+    // Transform the data to match frontend expectations
+    const transformedSchedules = schedules.map((schedule) => ({
+      id: schedule.id,
+      courseId: schedule.course?.id || '',
+      courseName: schedule.course?.name || '',
+      academicPeriodId: schedule.periodId,
+      academicPeriodName: schedule.period
+        ? `${schedule.period.periodName}${
+            schedule.period.batchName ? ` - ${schedule.period.batchName}` : ''
+          }`
+        : '',
+      teacherId: schedule.teacherId,
+      teacherName: schedule.teacher
+        ? `${schedule.teacher.firstName} ${schedule.teacher.lastName}`
+        : '',
+      location: schedule.location,
+      days: schedule.days,
+      time_start: schedule.time_start,
+      time_end: schedule.time_end,
+      periodStart: schedule.periodStart
+        ? schedule.periodStart.toISOString().split('T')[0]
+        : null,
+      periodEnd: schedule.periodEnd
+        ? schedule.periodEnd.toISOString().split('T')[0]
+        : null,
+      color: schedule.color || '#FFCF00',
+      notes: schedule.notes,
+      createdAt: schedule.createdAt,
+      updatedAt: schedule.updatedAt,
+    }));
+
+    res.json(transformedSchedules);
+  } catch (err) {
+    console.error('Get schedules error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to get schedules',
+    });
+  }
+};
+
+/**
+ * Get a single schedule by ID
+ */
+export const getSchedule = async (req, res) => {
+  try {
+    const schedule = await ScheduleModel.getScheduleById(req.params.id);
+
+    if (!schedule) {
+      return res.status(404).json({
+        error: true,
+        message: 'Schedule not found',
+      });
+    }
+
+    // Transform the data
+    const transformedSchedule = {
+      id: schedule.id,
+      courseId: schedule.course,
+      courseName: schedule.course?.name || '',
+      academicPeriodId: schedule.periodId,
+      academicPeriodName: schedule.period
+        ? `${schedule.period.periodName}${
+            schedule.period.batchName ? ` - ${schedule.period.batchName}` : ''
+          }`
+        : '',
+      teacherId: schedule.teacherId,
+      teacherName: schedule.teacher
+        ? `${schedule.teacher.firstName} ${schedule.teacher.lastName}`
+        : '',
+      location: schedule.location,
+      days: schedule.days,
+      time_start: schedule.time_start,
+      time_end: schedule.time_end,
+      periodStart: schedule.periodStart
+        ? schedule.periodStart.toISOString().split('T')[0]
+        : null,
+      periodEnd: schedule.periodEnd
+        ? schedule.periodEnd.toISOString().split('T')[0]
+        : null,
+      color: schedule.color || '#FFCF00',
+      notes: schedule.notes,
+      createdAt: schedule.createdAt,
+      updatedAt: schedule.updatedAt,
+    };
+
+    res.json(transformedSchedule);
+  } catch (err) {
+    console.error('Get schedule error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to get schedule',
+    });
+  }
+};
+
+/**
+ * Get schedules by academic period
+ */
+export const getSchedulesByPeriod = async (req, res) => {
+  try {
+    const schedules = await ScheduleModel.getSchedulesByPeriod(
+      req.params.periodId
+    );
+    res.json(schedules);
+  } catch (err) {
+    console.error('Get schedules by period error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to get schedules',
+    });
+  }
+};
+
+/**
+ * Get schedules by teacher
+ */
+export const getSchedulesByTeacher = async (req, res) => {
+  try {
+    const schedules = await ScheduleModel.getSchedulesByTeacher(
+      req.params.teacherId
+    );
+    res.json(schedules);
+  } catch (err) {
+    console.error('Get schedules by teacher error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to get schedules',
+    });
+  }
+};
+
+/**
+ * Create a new schedule
+ * Only admins can create schedules
+ */
+export const createSchedule = async (req, res) => {
+  try {
+    // Check for schedule conflicts
+    const conflicts = await ScheduleModel.checkScheduleConflicts(req.body);
+
+    if (conflicts.length > 0) {
+      return res.status(409).json({
+        error: true,
+        message: 'Schedule conflict detected',
+        conflicts: conflicts.map((c) => ({
+          id: c.id,
+          courseName: c.course?.name,
+          days: c.days,
+          time_start: c.time_start,
+          time_end: c.time_end,
+        })),
+      });
+    }
+
+    const body = {
+      courseId: req.body.courseId,
+      academicPeriodId: req.body.academicPeriodId,
+      teacherId: req.body.teacherId,
+      location: req.body.location,
+      days: req.body.days,
+      time_start: req.body.time_start,
+      time_end: req.body.time_end,
+      periodStart: req.body.periodStart,
+      periodEnd: req.body.periodEnd,
+      color: req.body.color,
+      notes: req.body.notes,
+    };
+
+    const schedule = await ScheduleModel.createSchedule(body);
+
+    // Transform the response
+    const transformedSchedule = {
+      id: schedule.id,
+      course: schedule.courseId,
+      courseName: schedule.course?.name || '',
+      academicPeriodId: schedule.periodId,
+      teacherId: schedule.teacherId,
+      teacherName: schedule.teacher
+        ? `${schedule.teacher.firstName} ${schedule.teacher.lastName}`
+        : '',
+      location: schedule.location,
+      days: schedule.days,
+      time_start: schedule.time_start,
+      time_end: schedule.time_end,
+      periodStart: schedule.periodStart
+        ? schedule.periodStart.toISOString().split('T')[0]
+        : null,
+      periodEnd: schedule.periodEnd
+        ? schedule.periodEnd.toISOString().split('T')[0]
+        : null,
+      color: schedule.color || '#FFCF00',
+      notes: schedule.notes,
+    };
+
+    res.status(201).json(transformedSchedule);
+  } catch (err) {
+    console.error('Create schedule error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to create schedule',
+      details: err.message,
+    });
+  }
+};
+
+/**
+ * Update a schedule
+ * Only admins can update schedules
+ */
+export const updateSchedule = async (req, res) => {
+  try {
+    // Check if schedule exists
+    const existingSchedule = await ScheduleModel.getScheduleById(req.params.id);
+
+    if (!existingSchedule) {
+      return res.status(404).json({
+        error: true,
+        message: 'Schedule not found',
+      });
+    }
+
+    // Check for schedule conflicts (excluding current schedule)
+    if (req.body.teacherId || req.body.days || req.body.time_start) {
+      const conflicts = await ScheduleModel.checkScheduleConflicts(
+        {
+          ...existingSchedule,
+          ...req.body,
+        },
+        req.params.id
+      );
+
+      if (conflicts.length > 0) {
+        return res.status(409).json({
+          error: true,
+          message: 'Schedule conflict detected',
+          conflicts: conflicts.map((c) => ({
+            id: c.id,
+            courseName: c.course?.name,
+            days: c.days,
+            time_start: c.time_start,
+            time_end: c.time_end,
+          })),
+        });
+      }
+    }
+
+    const schedule = await ScheduleModel.updateSchedule(
+      req.params.id,
+      req.body
+    );
+
+    // Transform the response
+    const transformedSchedule = {
+      id: schedule.id,
+      course: schedule.courseId,
+      courseName: schedule.course?.name || '',
+      academicPeriodId: schedule.periodId,
+      teacherId: schedule.teacherId,
+      teacherName: schedule.teacher
+        ? `${schedule.teacher.firstName} ${schedule.teacher.lastName}`
+        : '',
+      location: schedule.location,
+      days: schedule.days,
+      time_start: schedule.time_start,
+      time_end: schedule.time_end,
+      periodStart: schedule.periodStart
+        ? schedule.periodStart.toISOString().split('T')[0]
+        : null,
+      periodEnd: schedule.periodEnd
+        ? schedule.periodEnd.toISOString().split('T')[0]
+        : null,
+      color: schedule.color || '#FFCF00',
+      notes: schedule.notes,
+    };
+
+    res.json(transformedSchedule);
+  } catch (err) {
+    console.error('Update schedule error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to update schedule',
+      details: err.message,
+    });
+  }
+};
+
+/**
+ * Delete a schedule (soft delete)
+ * Only admins can delete schedules
+ */
+export const deleteSchedule = async (req, res) => {
+  try {
+    const schedule = await ScheduleModel.getScheduleById(req.params.id);
+
+    if (!schedule) {
+      return res.status(404).json({
+        error: true,
+        message: 'Schedule not found',
+      });
+    }
+
+    await ScheduleModel.deleteSchedule(req.params.id);
+
+    res.json({
+      success: true,
+      message: 'Schedule deleted successfully',
+    });
+  } catch (err) {
+    console.error('Delete schedule error:', err);
+    res.status(500).json({
+      error: true,
+      message: 'Failed to delete schedule',
+    });
+  }
+};

--- a/api/controller/user_controller.js
+++ b/api/controller/user_controller.js
@@ -413,6 +413,206 @@ const inspectEmailExists = async (req, res) => {
   }
 };
 
+// Search students with enrollment indicator for a course within an academic period
+const searchStudentsForCoursePeriod = async (req, res) => {
+  try {
+    const {
+      q,
+      periodId,
+      courseId,
+      take = 20,
+      page = 1,
+      enrolledOnly,
+    } = req.query;
+
+    if (!periodId || !courseId) {
+      return res
+        .status(400)
+        .json({ error: true, message: 'periodId and courseId are required' });
+    }
+
+    // If the request is specifically for enrolled students only, pull directly from user_schedule
+    if (String(enrolledOnly) === 'true') {
+      const enrolled = await prisma.user_schedule.findMany({
+        where: {
+          deletedAt: null,
+          schedule: {
+            deletedAt: null,
+            courseId,
+            periodId,
+          },
+          user: {
+            deletedAt: null,
+            role: 'student',
+            ...(q
+              ? {
+                  OR: [
+                    { userId: { contains: q } },
+                    { firstName: { contains: q } },
+                    { middleName: { contains: q } },
+                    { lastName: { contains: q } },
+                    { email: { contains: q } },
+                  ],
+                }
+              : {}),
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              userId: true,
+              firstName: true,
+              middleName: true,
+              lastName: true,
+              email: true,
+              status: true,
+            },
+          },
+        },
+        take: parseInt(take),
+        skip: (parseInt(page) - 1) * parseInt(take),
+      });
+
+      const data = enrolled
+        .map((e) => e.user)
+        .filter(Boolean)
+        .map((s) => ({
+          ...s,
+          name: `${s.firstName}${s.middleName ? ' ' + s.middleName : ''} ${
+            s.lastName
+          }`.trim(),
+          enrolledInCourse: true,
+        }));
+
+      return res.json(data);
+    }
+
+    // Otherwise, search students and annotate whether enrolled
+    const whereClause = {
+      role: 'student',
+      deletedAt: null,
+      ...(q
+        ? {
+            OR: [
+              { userId: { contains: q } },
+              { firstName: { contains: q } },
+              { middleName: { contains: q } },
+              { lastName: { contains: q } },
+              { email: { contains: q } },
+            ],
+          }
+        : {}),
+    };
+
+    const students = await prisma.users.findMany({
+      where: whereClause,
+      select: {
+        id: true,
+        userId: true,
+        firstName: true,
+        middleName: true,
+        lastName: true,
+        email: true,
+        status: true,
+      },
+      take: parseInt(take),
+      skip: (parseInt(page) - 1) * parseInt(take),
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const studentIds = students.map((s) => s.id);
+
+    const userSchedules = await prisma.user_schedule.findMany({
+      where: {
+        userId: { in: studentIds },
+        deletedAt: null,
+        schedule: {
+          deletedAt: null,
+          courseId,
+          periodId: periodId,
+        },
+      },
+      select: { userId: true },
+    });
+
+    const enrolledSet = new Set(userSchedules.map((us) => us.userId));
+
+    const data = students.map((s) => ({
+      ...s,
+      name: `${s.firstName}${s.middleName ? ' ' + s.middleName : ''} ${
+        s.lastName
+      }`.trim(),
+      enrolledInCourse: enrolledSet.has(s.id),
+    }));
+
+    res.json(data);
+  } catch (error) {
+    console.error('searchStudentsForCoursePeriod error', error);
+    res.status(500).json({ error: true, message: 'Failed to search students' });
+  }
+};
+
+// Check schedule conflicts for a student within an academic period
+const checkStudentScheduleConflicts = async (req, res) => {
+  try {
+    const { studentId, periodId, days, time_start, time_end } = req.body;
+
+    if (!studentId || !periodId || !days || !time_start || !time_end) {
+      return res.status(400).json({
+        error: true,
+        message:
+          'studentId, periodId, days, time_start and time_end are required',
+      });
+    }
+
+    const daysArray = days.split(',').map((d) => d.trim());
+
+    // Get all schedules the student is already attached to within the period
+    const existing = await prisma.user_schedule.findMany({
+      where: {
+        userId: studentId,
+        deletedAt: null,
+        schedule: {
+          deletedAt: null,
+          periodId,
+        },
+      },
+      include: {
+        schedule: true,
+      },
+    });
+
+    const conflicts = existing.filter((us) => {
+      const s = us.schedule;
+      if (!s) return false;
+      const scheduleDays = (s.days || '').split(',').map((d) => d.trim());
+      const daysOverlap = daysArray.some((d) => scheduleDays.includes(d));
+      if (!daysOverlap) return false;
+
+      const timeOverlap =
+        time_start < (s.time_end || '') && time_end > (s.time_start || '');
+      return timeOverlap;
+    });
+
+    res.json({
+      hasConflicts: conflicts.length > 0,
+      conflicts: conflicts.map((c) => ({
+        scheduleId: c.scheduleId,
+        days: c.schedule?.days,
+        time_start: c.schedule?.time_start,
+        time_end: c.schedule?.time_end,
+        courseId: c.schedule?.courseId,
+      })),
+    });
+  } catch (error) {
+    console.error('checkStudentScheduleConflicts error', error);
+    res
+      .status(500)
+      .json({ error: true, message: 'Failed to check schedule conflicts' });
+  }
+};
+
 export {
   getAllUsers,
   getUserById,
@@ -424,4 +624,6 @@ export {
   changePassword,
   createStudentAccount,
   inspectEmailExists,
+  searchStudentsForCoursePeriod,
+  checkStudentScheduleConflicts,
 };

--- a/api/middleware/scheduleValidator.js
+++ b/api/middleware/scheduleValidator.js
@@ -1,0 +1,266 @@
+import Joi from 'joi';
+
+/**
+ * Schema for creating a schedule
+ */
+const createScheduleSchema = Joi.object({
+  courseId: Joi.string().required().messages({
+    'any.required': 'Course is required',
+    'string.empty': 'Course is required',
+  }),
+  academicPeriodId: Joi.string().required().messages({
+    'any.required': 'Academic period is required',
+    'string.empty': 'Academic period is required',
+  }),
+  teacherId: Joi.string().required().messages({
+    'any.required': 'Teacher/Organizer is required',
+    'string.empty': 'Teacher/Organizer is required',
+  }),
+  location: Joi.string().required().messages({
+    'any.required': 'Location is required',
+    'string.empty': 'Location is required',
+  }),
+  days: Joi.string()
+    .required()
+    .pattern(/^(M|T|W|TH|F|S|SU)(,(M|T|W|TH|F|S|SU))*$/)
+    .messages({
+      'any.required': 'Days are required',
+      'string.pattern.base': 'Days must be in format: M,W,F or T,TH',
+    }),
+  time_start: Joi.string().required().messages({
+    'any.required': 'Start time is required',
+    'string.empty': 'Start time is required',
+  }),
+  time_end: Joi.string().required().messages({
+    'any.required': 'End time is required',
+    'string.empty': 'End time is required',
+  }),
+  periodStart: Joi.date().iso().required().messages({
+    'any.required': 'Schedule start date is required',
+    'date.format': 'Invalid start date format',
+  }),
+  periodEnd: Joi.date()
+    .iso()
+    .required()
+    .greater(Joi.ref('periodStart'))
+    .messages({
+      'any.required': 'Schedule end date is required',
+      'date.format': 'Invalid end date format',
+      'date.greater': 'End date must be after start date',
+    }),
+  color: Joi.string()
+    .pattern(/^#[0-9A-F]{6}$/i)
+    .default('#FFCF00')
+    .messages({
+      'string.pattern.base': 'Color must be a valid hex code',
+    }),
+  notes: Joi.string().allow('', null).optional(),
+  time: Joi.string().allow('', null).optional(), // For backward compatibility
+});
+
+/**
+ * Schema for updating a schedule
+ */
+const updateScheduleSchema = Joi.object({
+  courseId: Joi.string().optional(),
+  periodId: Joi.string().optional(),
+  teacherId: Joi.string().optional(),
+  location: Joi.string().optional(),
+  days: Joi.string()
+    .optional()
+    .pattern(/^(M|T|W|TH|F|S|SU)(,(M|T|W|TH|F|S|SU))*$/)
+    .messages({
+      'string.pattern.base': 'Days must be in format: M,W,F or T,TH',
+    }),
+  time_start: Joi.string().optional(),
+  time_end: Joi.string().optional(),
+  periodStart: Joi.date().iso().optional(),
+  periodEnd: Joi.date().iso().optional(),
+  color: Joi.string()
+    .pattern(/^#[0-9A-F]{6}$/i)
+    .optional()
+    .messages({
+      'string.pattern.base': 'Color must be a valid hex code',
+    }),
+  notes: Joi.string().allow('', null).optional(),
+  time: Joi.string().allow('', null).optional(),
+}).min(1);
+
+/**
+ * Validate time constraints
+ * - Start time must be before end time
+ * - End time cannot be later than 9:00 PM (21:00)
+ * - Minimum duration is 30 minutes
+ */
+const validateTimeConstraints = (req, res, next) => {
+  const { time_start, time_end } = req.body;
+
+  if (!time_start || !time_end) {
+    // Skip validation if times are not provided (for partial updates)
+    return next();
+  }
+
+  // Convert time strings to comparable format
+  const parseTime = (timeStr) => {
+    // Handle both 12-hour (10:00 AM) and 24-hour (10:00) formats
+    const normalized = timeStr.trim();
+    const isPM = normalized.toLowerCase().includes('pm');
+    const isAM = normalized.toLowerCase().includes('am');
+    const timeMatch = normalized.match(/(\d+):(\d+)/);
+
+    if (!timeMatch) return null;
+
+    let hour = parseInt(timeMatch[1], 10);
+    const minute = parseInt(timeMatch[2], 10);
+
+    // Convert to 24-hour format
+    if (isPM && hour !== 12) {
+      hour += 12;
+    } else if (isAM && hour === 12) {
+      hour = 0;
+    }
+
+    return hour * 60 + minute; // Return total minutes
+  };
+
+  const startMinutes = parseTime(time_start);
+  const endMinutes = parseTime(time_end);
+
+  if (startMinutes === null || endMinutes === null) {
+    return res.status(400).json({
+      error: true,
+      message: 'Invalid time format',
+    });
+  }
+
+  // Check start time is before end time
+  if (startMinutes >= endMinutes) {
+    return res.status(400).json({
+      error: true,
+      message: 'Start time must be before end time',
+    });
+  }
+
+  // Check minimum duration (30 minutes)
+  const durationMinutes = endMinutes - startMinutes;
+  if (durationMinutes < 30) {
+    return res.status(400).json({
+      error: true,
+      message: 'Schedule duration must be at least 30 minutes',
+    });
+  }
+
+  // Check latest end time (9:00 PM = 21:00 = 1260 minutes)
+  if (endMinutes > 21 * 60 + 1) {
+    return res.status(400).json({
+      error: true,
+      message: 'Latest end time is 9:00 PM',
+    });
+  }
+
+  next();
+};
+
+/**
+ * Validate schedule dates are within academic period boundaries
+ */
+const validateDateBoundaries = async (req, res, next) => {
+  const { periodId, periodStart, periodEnd } = req.body;
+
+  if (!periodId || !periodStart || !periodEnd) {
+    // Skip validation if not all required fields are present
+    return next();
+  }
+
+  try {
+    const { PrismaClient } = await import('@prisma/client');
+    const prisma = new PrismaClient();
+
+    // Fetch the academic period
+    const academicPeriod = await prisma.academic_period.findUnique({
+      where: { id: periodId },
+      select: { startAt: true, endAt: true },
+    });
+
+    if (!academicPeriod) {
+      return res.status(404).json({
+        error: true,
+        message: 'Academic period not found',
+      });
+    }
+
+    const scheduleStart = new Date(periodStart);
+    const scheduleEnd = new Date(periodEnd);
+    const periodStartDate = new Date(academicPeriod.startAt);
+    const periodEndDate = new Date(academicPeriod.endAt);
+
+    // Check if schedule dates are within academic period boundaries
+    if (scheduleStart < periodStartDate || scheduleEnd > periodEndDate) {
+      return res.status(400).json({
+        error: true,
+        message: `Schedule dates must be within the academic period range: ${periodStartDate.toLocaleDateString()} - ${periodEndDate.toLocaleDateString()}`,
+      });
+    }
+
+    // Check schedule end is after start
+    if (scheduleStart > scheduleEnd) {
+      return res.status(400).json({
+        error: true,
+        message: 'Schedule end date must be after start date',
+      });
+    }
+
+    await prisma.$disconnect();
+    next();
+  } catch (error) {
+    console.error('Date validation error:', error);
+    return res.status(500).json({
+      error: true,
+      message: 'Failed to validate schedule dates',
+    });
+  }
+};
+
+/**
+ * Middleware to validate schedule creation
+ */
+export const validateCreateSchedule = (req, res, next) => {
+  const { error } = createScheduleSchema.validate(req.body, {
+    abortEarly: false,
+    stripUnknown: true,
+  });
+
+  if (error) {
+    const errors = error.details.map((detail) => detail.message);
+    return res.status(400).json({
+      error: true,
+      message: 'Validation failed',
+      details: errors,
+    });
+  }
+
+  next();
+};
+
+/**
+ * Middleware to validate schedule update
+ */
+export const validateUpdateSchedule = (req, res, next) => {
+  const { error } = updateScheduleSchema.validate(req.body, {
+    abortEarly: false,
+    stripUnknown: true,
+  });
+
+  if (error) {
+    const details = error.details.map((detail) => detail.message);
+    return res.status(400).json({
+      error: true,
+      message: details.join(', '),
+      details: details,
+    });
+  }
+
+  next();
+};
+
+export { validateTimeConstraints, validateDateBoundaries };

--- a/api/middleware/userValidator.js
+++ b/api/middleware/userValidator.js
@@ -1,14 +1,23 @@
-import Joi from "joi";
+import Joi from 'joi';
 
 // Define the validation schema
 const userSchema = Joi.object({
-  userId: Joi.string().min(1).max(100),
-  firstName: Joi.string().min(2).trim(),
-  lastName: Joi.string().min(2).trim(),
-  email: Joi.string().email(),
-  password: Joi.string().min(8).max(100),
-  role: Joi.string().valid("student", "teacher", "admin"),
-}).min(1); // Require at least one field to be present
+  userId: Joi.string().min(1).max(100).optional(),
+  firstName: Joi.string().min(2).trim().required(),
+  lastName: Joi.string().min(2).trim().required(),
+  email: Joi.string().email().required(),
+  password: Joi.string().min(8).max(100).required(),
+  role: Joi.string().valid('student', 'teacher', 'admin').default('student'),
+  middleName: Joi.string().trim().optional(),
+  phoneNumber: Joi.string().optional(),
+  birthmonth: Joi.number().integer().min(1).max(12).optional(),
+  birthdate: Joi.number().integer().min(1).max(31).optional(),
+  birthyear: Joi.number()
+    .integer()
+    .min(1900)
+    .max(new Date().getFullYear())
+    .optional(),
+});
 
 // Middleware function
 const validateUpdateUser = (req, res, next) => {
@@ -20,7 +29,7 @@ const validateUpdateUser = (req, res, next) => {
   if (error) {
     return res.status(400).json({
       error: true,
-      message: "Validation error",
+      message: 'Validation error',
       errors: error.details.map((err) => ({
         field: err.path[0],
         message: err.message,
@@ -40,7 +49,7 @@ const validateCreateUser = (req, res, next) => {
   if (error) {
     return res.status(400).json({
       error: true,
-      message: "Validation error",
+      message: 'Validation error',
       errors: error.details.map((err) => ({
         field: err.path[0],
         message: err.message,

--- a/api/model/course_model.js
+++ b/api/model/course_model.js
@@ -1,53 +1,53 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 export const getAllCourses = (isStudent) => {
-    return prisma.course.findMany({
-        where: {
-            deletedAt: null,
-            ...(isStudent ? { visibility: 'visible' } : {})
-        },
-        include: {
-            adviser: {
-                select: {
-                    id: true,
-                    firstName: true,
-                    middleName: true,
-                    lastName: true
-                }
-            }
-        }
-    });
+  return prisma.course.findMany({
+    where: {
+      deletedAt: null,
+      ...(isStudent ? { visibility: 'visible' } : {}),
+    },
+    // include: {
+    //     adviser: {
+    //         select: {
+    //             id: true,
+    //             firstName: true,
+    //             middleName: true,
+    //             lastName: true
+    //         }
+    //     }
+    // }
+  });
 };
 
 export const getCourseById = (id) => {
-    return prisma.course.findUnique({ 
-        where: { id },
-        select: {
-            id: true,
-            name: true,
-            adviser: {
-                select: {
-                    id: true,
-                    firstName: true,
-                    lastName: true
-                }
-            }
-        }
-    });
+  return prisma.course.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      // adviser: {
+      //     select: {
+      //         id: true,
+      //         firstName: true,
+      //         lastName: true
+      //     }
+      // }
+    },
+  });
 };
 
 export const createCourse = (data) => {
-    return prisma.course.create({ data });
+  return prisma.course.create({ data });
 };
 
 export const updateCourse = (id, data) => {
-    return prisma.course.update({ where: { id }, data });
+  return prisma.course.update({ where: { id }, data });
 };
 
 export const deleteCourse = (id) => {
-    return prisma.course.update({
-        where: { id },
-        data: { deletedAt: new Date() }
-    });
+  return prisma.course.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
 };

--- a/api/model/schedule_model.js
+++ b/api/model/schedule_model.js
@@ -1,0 +1,359 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+/**
+ * Get all schedules with related data
+ * @param {Object} options - Query options
+ * @returns {Promise<Array>} Array of schedules
+ */
+export const getAllSchedules = async (options = {}) => {
+  const {
+    includeCourse = true,
+    includePeriod = true,
+    includeTeacher = true,
+  } = options;
+
+  return prisma.schedule.findMany({
+    where: {
+      deletedAt: null,
+    },
+    include: {
+      course: includeCourse
+        ? {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              visibility: true,
+            },
+          }
+        : false,
+      period: includePeriod
+        ? {
+            select: {
+              id: true,
+              periodName: true,
+              batchName: true,
+              startAt: true,
+              endAt: true,
+              status: true,
+            },
+          }
+        : false,
+      teacher: includeTeacher
+        ? {
+            select: {
+              id: true,
+              userId: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+            },
+          }
+        : false,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+};
+
+/**
+ * Get schedule by ID with related data
+ * @param {number} id - Schedule ID
+ * @returns {Promise<Object|null>} Schedule object or null
+ */
+export const getScheduleById = async (id) => {
+  return prisma.schedule.findUnique({
+    where: { id: parseInt(id) },
+    include: {
+      course: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+        },
+      },
+      period: {
+        select: {
+          id: true,
+          periodName: true,
+          batchName: true,
+          startAt: true,
+          endAt: true,
+        },
+      },
+      teacher: {
+        select: {
+          id: true,
+          userId: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Get schedules by academic period
+ * @param {string} periodId - Academic period ID
+ * @returns {Promise<Array>} Array of schedules
+ */
+export const getSchedulesByPeriod = async (periodId) => {
+  return prisma.schedule.findMany({
+    where: {
+      periodId,
+      deletedAt: null,
+    },
+    include: {
+      course: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      teacher: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Get schedules by teacher
+ * @param {string} teacherId - Teacher ID
+ * @returns {Promise<Array>} Array of schedules
+ */
+export const getSchedulesByTeacher = async (teacherId) => {
+  return prisma.schedule.findMany({
+    where: {
+      teacherId,
+      deletedAt: null,
+    },
+    include: {
+      course: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      period: {
+        select: {
+          id: true,
+          periodName: true,
+          batchName: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Create a new schedule
+ * @param {Object} data - Schedule data
+ * @returns {Promise<Object>} Created schedule
+ */
+export const createSchedule = async (data) => {
+  // Convert date strings to Date objects if provided
+  const scheduleData = {
+    days: data.days,
+    time_start: data.time_start,
+    time_end: data.time_end,
+    location: data.location,
+    notes: data.notes,
+    color: data.color,
+    periodStart: data.periodStart ? new Date(data.periodStart) : null,
+    periodEnd: data.periodEnd ? new Date(data.periodEnd) : null,
+    course: data.courseId ? { connect: { id: data.courseId } } : undefined,
+    period: data.academicPeriodId
+      ? { connect: { id: data.academicPeriodId } }
+      : undefined,
+    teacher: data.teacherId ? { connect: { id: data.teacherId } } : undefined,
+  };
+
+  return prisma.schedule.create({
+    data: scheduleData,
+    include: {
+      course: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      period: {
+        select: {
+          id: true,
+          periodName: true,
+          batchName: true,
+        },
+      },
+      teacher: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Update a schedule
+ * @param {number} id - Schedule ID
+ * @param {Object} data - Updated schedule data
+ * @returns {Promise<Object>} Updated schedule
+ */
+export const updateSchedule = async (id, data) => {
+  // Convert date strings to Date objects if provided
+  const scheduleData = {
+    days: data.days,
+    time_start: data.time_start,
+    time_end: data.time_end,
+    location: data.location,
+    notes: data.notes,
+    color: data.color,
+  };
+
+  if (data.periodStart) {
+    scheduleData.periodStart = new Date(data.periodStart);
+  }
+  if (data.periodEnd) {
+    scheduleData.periodEnd = new Date(data.periodEnd);
+  }
+
+  // Handle relationship connections
+  if (data.courseId) {
+    scheduleData.course = { connect: { id: data.courseId } };
+  }
+  if (data.academicPeriodId) {
+    scheduleData.period = { connect: { id: data.academicPeriodId } };
+  }
+  if (data.teacherId) {
+    scheduleData.teacher = { connect: { id: data.teacherId } };
+  }
+
+  return prisma.schedule.update({
+    where: { id: parseInt(id) },
+    data: scheduleData,
+    include: {
+      course: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      period: {
+        select: {
+          id: true,
+          periodName: true,
+          batchName: true,
+        },
+      },
+      teacher: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  });
+};
+
+/**
+ * Soft delete a schedule
+ * @param {number} id - Schedule ID
+ * @returns {Promise<Object>} Deleted schedule
+ */
+export const deleteSchedule = async (id) => {
+  return prisma.schedule.update({
+    where: { id: parseInt(id) },
+    data: { deletedAt: new Date() },
+  });
+};
+
+/**
+ * Check for schedule conflicts
+ * @param {Object} scheduleData - Schedule data to check
+ * @param {number} excludeId - Schedule ID to exclude from check (for updates)
+ * @returns {Promise<Array>} Array of conflicting schedules
+ */
+export const checkScheduleConflicts = async (
+  scheduleData,
+  excludeId = null
+) => {
+  const { teacherId, days, time_start, time_end, periodStart, periodEnd } =
+    scheduleData;
+
+  if (!teacherId || !days || !time_start || !time_end) {
+    return [];
+  }
+
+  // Parse days array
+  const daysArray = days.split(',').map((d) => d.trim());
+
+  // Find schedules with same teacher and overlapping days
+  const conflictingSchedules = await prisma.schedule.findMany({
+    where: {
+      teacherId,
+      deletedAt: null,
+      ...(excludeId ? { id: { not: parseInt(excludeId) } } : {}),
+      days: {
+        in: daysArray.map((day) => days), // This is a simplified check
+      },
+    },
+    include: {
+      course: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  // Filter for time and date overlaps
+  return conflictingSchedules.filter((schedule) => {
+    // Check if days overlap
+    const scheduleDays = schedule.days.split(',').map((d) => d.trim());
+    const daysOverlap = daysArray.some((day) => scheduleDays.includes(day));
+
+    if (!daysOverlap) return false;
+
+    // Check if time periods overlap
+    const newStart = time_start;
+    const newEnd = time_end;
+    const existingStart = schedule.time_start;
+    const existingEnd = schedule.time_end;
+
+    const timeOverlap = newStart < existingEnd && newEnd > existingStart;
+
+    if (!timeOverlap) return false;
+
+    // Check if date ranges overlap
+    if (
+      periodStart &&
+      periodEnd &&
+      schedule.periodStart &&
+      schedule.periodEnd
+    ) {
+      const newPeriodStart = new Date(periodStart);
+      const newPeriodEnd = new Date(periodEnd);
+      const existingPeriodStart = new Date(schedule.periodStart);
+      const existingPeriodEnd = new Date(schedule.periodEnd);
+
+      const dateOverlap =
+        newPeriodStart <= existingPeriodEnd &&
+        newPeriodEnd >= existingPeriodStart;
+      return dateOverlap;
+    }
+
+    return true;
+  });
+};

--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js",
     "seed_students": "node prisma/seed_students_sample.js",
     "dev": "nodemon -e js,mysql,env -w .env -w . index.js",
-    "build": "npx prisma db push && npx prisma generate && npx prisma db seed",
+    "build": "npx prisma migrate deploy && npx prisma generate && npx prisma db seed",
     "seed": "node prisma/seed.js"
   },
   "dependencies": {

--- a/api/prisma/migrations/20251002195802_add_schedules/migration.sql
+++ b/api/prisma/migrations/20251002195802_add_schedules/migration.sql
@@ -1,0 +1,34 @@
+-- AlterTable
+ALTER TABLE `users` MODIFY `profilePicLink` LONGTEXT NULL;
+
+-- CreateTable
+CREATE TABLE `schedule` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `days` VARCHAR(191) NOT NULL,
+    `time` VARCHAR(191) NOT NULL,
+    `courseId` VARCHAR(191) NULL,
+    `periodId` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `deletedAt` DATETIME(3) NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `user_schedule` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` VARCHAR(191) NULL,
+    `scheduleId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `deletedAt` DATETIME(3) NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `schedule` ADD CONSTRAINT `schedule_courseId_fkey` FOREIGN KEY (`courseId`) REFERENCES `course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `schedule` ADD CONSTRAINT `schedule_periodId_fkey` FOREIGN KEY (`periodId`) REFERENCES `academic_period`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/migrations/20251002201519_adjust_schedules_and_advisers/migration.sql
+++ b/api/prisma/migrations/20251002201519_adjust_schedules_and_advisers/migration.sql
@@ -1,0 +1,43 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `adviserId` on the `course` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `course` DROP FOREIGN KEY `course_adviserId_fkey`;
+
+-- AlterTable
+ALTER TABLE `course` DROP COLUMN `adviserId`;
+
+-- AlterTable
+ALTER TABLE `schedule` ADD COLUMN `teacherId` VARCHAR(191) NULL;
+
+-- CreateTable
+CREATE TABLE `student_enrollment` (
+    `id` VARCHAR(191) NOT NULL,
+    `studentId` VARCHAR(191) NOT NULL,
+    `periodId` VARCHAR(191) NOT NULL,
+    `status` ENUM('enrolled', 'completed', 'dropped', 'withdrawn') NOT NULL DEFAULT 'enrolled',
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `deletedAt` DATETIME(3) NULL,
+
+    UNIQUE INDEX `student_enrollment_studentId_periodId_key`(`studentId`, `periodId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `schedule` ADD CONSTRAINT `schedule_teacherId_fkey` FOREIGN KEY (`teacherId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `user_schedule` ADD CONSTRAINT `user_schedule_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `user_schedule` ADD CONSTRAINT `user_schedule_scheduleId_fkey` FOREIGN KEY (`scheduleId`) REFERENCES `schedule`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `student_enrollment` ADD CONSTRAINT `student_enrollment_studentId_fkey` FOREIGN KEY (`studentId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `student_enrollment` ADD CONSTRAINT `student_enrollment_periodId_fkey` FOREIGN KEY (`periodId`) REFERENCES `academic_period`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/migrations/20251004175654_add_schedule_fields/migration.sql
+++ b/api/prisma/migrations/20251004175654_add_schedule_fields/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE `schedule` ADD COLUMN `color` VARCHAR(191) NULL DEFAULT '#FFCF00',
+    ADD COLUMN `location` VARCHAR(191) NULL,
+    ADD COLUMN `notes` TEXT NULL,
+    ADD COLUMN `periodEnd` DATETIME(3) NULL,
+    ADD COLUMN `periodStart` DATETIME(3) NULL,
+    ADD COLUMN `time_end` VARCHAR(191) NULL,
+    ADD COLUMN `time_start` VARCHAR(191) NULL,
+    MODIFY `time` VARCHAR(191) NULL;
+
+-- AlterTable
+ALTER TABLE `users` MODIFY `profilePicLink` VARCHAR(191) NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -36,8 +36,10 @@ model users {
   resetTokenExpiry DateTime?
   changePassword Boolean @default(true)
 
-  advisedCourses course[] @relation("UserAdvisesCourses")
   posts         posts[]
+  teacherSchedules schedule[] @relation("TeacherSchedules")
+  studentSchedules user_schedule[] @relation("StudentSchedules")
+  enrollments   student_enrollment[] @relation("StudentEnrollments")
 }
 
 model enrollment_request {
@@ -83,11 +85,60 @@ model course {
   price     Decimal @db.Decimal(10, 2)
   schedule  Json?
 
-  adviserId String?
-  adviser   users? @relation("UserAdvisesCourses", fields: [adviserId], references: [id])
-
   courseRequisite course_requisite[]
   academicPeriods academic_period_courses[]
+  schedules schedule[]
+}
+
+model schedule {
+  id        Int   @id @default(autoincrement())
+  days      String
+  time      String
+  courseId  String?
+  periodId  String?
+  teacherId String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deletedAt DateTime?
+
+  course    course? @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  period    academic_period? @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  teacher   users? @relation("TeacherSchedules", fields: [teacherId], references: [id], onDelete: SetNull)
+  userSchedules user_schedule[]
+}
+
+model user_schedule {
+  id        Int   @id @default(autoincrement())
+  userId    String?
+  scheduleId Int?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deletedAt DateTime?
+
+  user      users? @relation("StudentSchedules", fields: [userId], references: [id], onDelete: Cascade)
+  schedule  schedule? @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+}
+
+model student_enrollment {
+  id        String   @id @default(cuid())
+  studentId String
+  periodId  String
+  status    EnrollmentStatus @default(enrolled)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deletedAt DateTime?
+
+  student   users @relation("StudentEnrollments", fields: [studentId], references: [id], onDelete: Cascade)
+  period    academic_period @relation("PeriodEnrollments", fields: [periodId], references: [id], onDelete: Cascade)
+
+  @@unique([studentId, periodId])
+}
+
+enum EnrollmentStatus {
+  enrolled
+  completed
+  dropped
+  withdrawn
 }
 
 model course_requisite {
@@ -113,6 +164,8 @@ model academic_period {
   deletedAt     DateTime?
 
   courses       academic_period_courses[]
+  schedules     schedule[]
+  enrollments   student_enrollment[] @relation("PeriodEnrollments")
 }
 
 model academic_period_courses{

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -93,7 +93,14 @@ model course {
 model schedule {
   id        Int   @id @default(autoincrement())
   days      String
-  time      String
+  time      String?
+  time_start String?
+  time_end   String?
+  location   String?
+  notes      String? @db.Text
+  color      String? @default("#FFCF00")
+  periodStart DateTime?
+  periodEnd   DateTime?
   courseId  String?
   periodId  String?
   teacherId String?

--- a/api/routes/v1/index_routes.js
+++ b/api/routes/v1/index_routes.js
@@ -8,6 +8,7 @@ import { router as courses } from './course_routes.js';
 import { router as academicPeriods } from './academic_period_routes.js';
 import { router as academicPeriodCourses } from './academic_period_courses_routes.js';
 import { router as posts } from './post_routes.js';
+import { router as schedules } from './schedule_routes.js';
 
 const router = express.Router();
 router.get('/', function (req, res) {
@@ -25,5 +26,6 @@ router.use('/courses', courses);
 router.use('/academic-periods', academicPeriods);
 router.use('/academic-period-courses', academicPeriodCourses);
 router.use('/posts', posts);
+router.use('/schedules', schedules);
 
 export default router;

--- a/api/routes/v1/post_routes.js
+++ b/api/routes/v1/post_routes.js
@@ -1,21 +1,24 @@
 import express from 'express';
 import {
-    getPosts,
-    createPost,
-    updatePost,
-    archivePost,
-    unarchivePost,
-    deletePost,
-    addFilesToPost,
-    deletePostFile,
+  getPosts,
+  createPost,
+  updatePost,
+  archivePost,
+  unarchivePost,
+  deletePost,
+  addFilesToPost,
+  deletePostFile,
 } from '../../controller/post_controller.js';
-import { verifyToken, validateIsActiveUser } from '../../middleware/authValidator.js';
+import {
+  verifyToken,
+  validateIsActiveUser,
+} from '../../middleware/authValidator.js';
 import { uploadMultiple } from '../../middleware/multerMiddleware.js';
 
 const router = express.Router();
 
 // Public routes (no auth required)
-router.get('/', getPosts); // Get all posts with optional filtering
+router.get('/', verifyToken, validateIsActiveUser, getPosts); // Get all posts with optional filtering
 
 // Protected routes (require authentication)
 router.use(verifyToken); // Apply authentication to all routes below
@@ -31,6 +34,5 @@ router.delete('/:id', deletePost); // Delete post (soft delete)
 // File management for posts
 router.post('/:id/files', uploadMultiple('files', 5), addFilesToPost); // Add files to existing post
 router.delete('/:postId/files/:fileId', deletePostFile); // Delete specific file from post
-
 
 export { router };

--- a/api/routes/v1/schedule_routes.js
+++ b/api/routes/v1/schedule_routes.js
@@ -7,6 +7,8 @@ import {
   createSchedule,
   updateSchedule,
   deleteSchedule,
+  addStudentToSchedule,
+  removeStudentsFromSchedule,
 } from '../../controller/schedule_controller.js';
 import {
   validateCreateSchedule,
@@ -85,5 +87,41 @@ router.put(
  * Admin-only route
  */
 router.delete('/:id', verifyToken, validateUserIsAdmin, deleteSchedule);
+
+/**
+ * POST /api/v1/schedules/:id/students
+ * Attach a student to a schedule
+ * Admins can attach students
+ */
+router.post(
+  '/:id/students',
+  verifyToken,
+  (req, res, next) => {
+    const role = req.user?.data?.role;
+    if (role === 'admin') return next();
+    return res
+      .status(403)
+      .json({ error: true, message: 'User is unauthorized' });
+  },
+  addStudentToSchedule
+);
+
+/**
+ * POST /api/v1/schedules/:id/students:batch-delete
+ * Batch remove students from a schedule
+ * Admins can remove students
+ */
+router.post(
+  '/:id/students:batch-delete',
+  verifyToken,
+  (req, res, next) => {
+    const role = req.user?.data?.role;
+    if (role === 'admin') return next();
+    return res
+      .status(403)
+      .json({ error: true, message: 'User is unauthorized' });
+  },
+  removeStudentsFromSchedule
+);
 
 export { router };

--- a/api/routes/v1/schedule_routes.js
+++ b/api/routes/v1/schedule_routes.js
@@ -1,0 +1,89 @@
+import express from 'express';
+import {
+  getSchedules,
+  getSchedule,
+  getSchedulesByPeriod,
+  getSchedulesByTeacher,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+} from '../../controller/schedule_controller.js';
+import {
+  validateCreateSchedule,
+  validateUpdateSchedule,
+  validateTimeConstraints,
+  validateDateBoundaries,
+} from '../../middleware/scheduleValidator.js';
+import {
+  verifyToken,
+  validateUserIsAdmin,
+} from '../../middleware/authValidator.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/v1/schedules
+ * Get all schedules
+ * Public route - anyone can view schedules
+ */
+router.get('/', verifyToken, getSchedules);
+
+/**
+ * GET /api/v1/schedules/:id
+ * Get a single schedule by ID
+ * Public route - anyone can view a schedule
+ */
+router.get('/:id', verifyToken, getSchedule);
+
+/**
+ * GET /api/v1/schedules/period/:periodId
+ * Get schedules by academic period
+ * Public route - anyone can view schedules by period
+ */
+router.get('/period/:periodId', verifyToken, getSchedulesByPeriod);
+
+/**
+ * GET /api/v1/schedules/teacher/:teacherId
+ * Get schedules by teacher
+ * Public route - anyone can view schedules by teacher
+ */
+router.get('/teacher/:teacherId', verifyToken, getSchedulesByTeacher);
+
+/**
+ * POST /api/v1/schedules
+ * Create a new schedule
+ * Admin-only route
+ */
+router.post(
+  '/',
+  verifyToken,
+  validateUserIsAdmin,
+  validateCreateSchedule,
+  validateTimeConstraints,
+  validateDateBoundaries,
+  createSchedule
+);
+
+/**
+ * PUT /api/v1/schedules/:id
+ * Update a schedule
+ * Admin-only route
+ */
+router.put(
+  '/:id',
+  verifyToken,
+  validateUserIsAdmin,
+  validateUpdateSchedule,
+  validateTimeConstraints,
+  validateDateBoundaries,
+  updateSchedule
+);
+
+/**
+ * DELETE /api/v1/schedules/:id
+ * Delete a schedule (soft delete)
+ * Admin-only route
+ */
+router.delete('/:id', verifyToken, validateUserIsAdmin, deleteSchedule);
+
+export { router };

--- a/api/routes/v1/user_routes.js
+++ b/api/routes/v1/user_routes.js
@@ -10,6 +10,8 @@ import {
   activateUser,
   createStudentAccount,
   inspectEmailExists,
+  searchStudentsForCoursePeriod,
+  checkStudentScheduleConflicts,
 } from '../../controller/user_controller.js';
 import {
   validateUpdateUser,
@@ -38,6 +40,31 @@ router.put(
 );
 router.get('/validate-token', verifyToken, getAllUsers);
 router.get('/', verifyToken, validateUserIsAdmin, getAllUsers);
+router.get(
+  '/search-students',
+  verifyToken,
+  (req, res, next) => {
+    // allow admin and teacher
+    const role = req.user?.data?.role;
+    if (role === 'admin' || role === 'teacher') return next();
+    return res
+      .status(403)
+      .json({ error: true, message: 'User is unauthorized' });
+  },
+  searchStudentsForCoursePeriod
+);
+router.post(
+  '/students/conflicts',
+  verifyToken,
+  (req, res, next) => {
+    const role = req.user?.data?.role;
+    if (role === 'admin' || role === 'teacher') return next();
+    return res
+      .status(403)
+      .json({ error: true, message: 'User is unauthorized' });
+  },
+  checkStudentScheduleConflicts
+);
 router.get('/:id', verifyToken, validateUserIsAdmin, getUserById);
 router.post(
   '/create',

--- a/api/routes/v1/user_routes.js
+++ b/api/routes/v1/user_routes.js
@@ -36,10 +36,11 @@ router.put(
   validateUpdateUser,
   updateUser
 );
+router.get('/validate-token', verifyToken, getAllUsers);
 router.get('/', verifyToken, validateUserIsAdmin, getAllUsers);
 router.get('/:id', verifyToken, validateUserIsAdmin, getUserById);
 router.post(
-  '/create/',
+  '/create',
   verifyToken,
   validateUserIsAdmin,
   validateCreateUser,

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Navigate,
   Route,
@@ -58,9 +58,18 @@ import AdminGrades from './pages/admin/Grades';
 import DocumentRequests from './pages/admin/DocumentRequests';
 import ManageDocuments from './pages/admin/ManageDocuments';
 import Chatbot from './pages/admin/Chatbot';
+import AdminSchedule from './pages/admin/Schedule';
 
 function App() {
-  const { isAuthenticated } = useAuthStore();
+  const { isAuthenticated, validateToken } = useAuthStore();
+
+  // Validate token on app load
+  useEffect(() => {
+    if (isAuthenticated) {
+      validateToken();
+    }
+  }, [isAuthenticated, validateToken]);
+
   return (
     <div className="App">
       <Router>
@@ -136,11 +145,18 @@ function App() {
                 <Route path="ledger" element={<AdminLedger />} />
                 <Route path="assessment" element={<AdminAssessment />} />
                 <Route path="managefees" element={<ManageFees />} />
-                <Route path="document-validation" element={<DocumentValidation />} />
+                <Route
+                  path="document-validation"
+                  element={<DocumentValidation />}
+                />
                 <Route path="grades" element={<AdminGrades />} />
-                <Route path="document-requests" element={<DocumentRequests />} />
+                <Route
+                  path="document-requests"
+                  element={<DocumentRequests />}
+                />
                 <Route path="manage-documents" element={<ManageDocuments />} />
                 <Route path="chatbot" element={<Chatbot />} />
+                <Route path="schedule" element={<AdminSchedule />} />
               </Route>
             </>
           ) : (

--- a/client/src/components/buttons/SecondaryButton.js
+++ b/client/src/components/buttons/SecondaryButton.js
@@ -1,11 +1,15 @@
 import React from 'react';
 
-const SecondaryButton = ({ onClick, children}) => {
-    return (
-        <button type="button" className="mt-5 w-11/12 h-10 self-center size-8 font-bold bg-german-red text-white-yellow-tone text-xl drop-shadow-md hover:bg-dark-red-2 ease-in duration-150" onClick={onClick}>
-            {children}
-        </button>
-    );
+const SecondaryButton = ({ onClick, children }) => {
+  return (
+    <button
+      type="button"
+      className="mt-5 w-11/12 h-10 self-center font-bold bg-german-red text-white-yellow-tone lg:text-xl text-md drop-shadow-md hover:bg-dark-red-2 ease-in duration-150"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
 };
 
-export default SecondaryButton
+export default SecondaryButton;

--- a/client/src/components/calendar/Calendar.js
+++ b/client/src/components/calendar/Calendar.js
@@ -3,13 +3,20 @@ import { FaGear } from 'react-icons/fa6';
 import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md';
 import DateTile from '../../components/calendar/DateTile';
 import DaysWeek from './DaysWeek';
+import WeekView from './WeekView';
+import Spinner from '../common/Spinner';
 
 function Calendar(schedule) {
+  const { events = [], onDateTimeClick } = schedule;
+  const [view_mode, setview_mode] = useState(0); // 0 = month, 1 = week
+  const [isLoadingView, setIsLoadingView] = useState(false);
   const [current_month, setcurrent_month] = useState(new Date().getMonth());
   const [current_year, setcurrent_year] = useState(new Date().getFullYear());
+  const [current_week_start, setcurrent_week_start] = useState(new Date());
   const [number_of_days, setnumber_of_days] = useState(0);
   const [show_dropdown, setshow_dropdown] = useState(false);
   const [show_year_dropdown, setshow_year_dropdown] = useState(false);
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const current_year_ref = useRef(null);
   const year_range = Array.from(
     { length: 21 },
@@ -81,16 +88,6 @@ function Calendar(schedule) {
     setshow_dropdown(false);
   };
 
-  const addYear = () => {
-    setcurrent_year(current_year + 1);
-    setshow_year_dropdown(false);
-  };
-
-  const subYear = () => {
-    setcurrent_year(current_year - 1);
-    setshow_year_dropdown(false);
-  };
-
   const changeYear = (num) => {
     if (num >= 1990 && num <= 3000) {
       setcurrent_year(num);
@@ -98,6 +95,54 @@ function Calendar(schedule) {
       setcurrent_year(new Date().getFullYear());
     }
     setshow_year_dropdown(false);
+  };
+
+  // Handle view mode change with loading state
+  const handleViewChange = (newMode) => {
+    if (newMode === view_mode) return;
+
+    setIsLoadingView(true);
+
+    // Simulate a brief loading delay for smooth transition
+    setTimeout(() => {
+      setview_mode(newMode);
+      setIsLoadingView(false);
+    }, 300);
+  };
+
+  // Week navigation functions
+  const getWeekDates = (startDate) => {
+    const dates = [];
+    const start = new Date(startDate);
+    // Get the Sunday of the week
+    const day = start.getDay();
+    const diff = start.getDate() - day;
+    const sunday = new Date(start.setDate(diff));
+
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(sunday);
+      date.setDate(sunday.getDate() + i);
+      dates.push(date);
+    }
+    return dates;
+  };
+
+  const addWeek = () => {
+    const newDate = new Date(current_week_start);
+    newDate.setDate(newDate.getDate() + 7);
+    setcurrent_week_start(newDate);
+    // Update month and year based on the new week
+    setcurrent_month(newDate.getMonth());
+    setcurrent_year(newDate.getFullYear());
+  };
+
+  const subWeek = () => {
+    const newDate = new Date(current_week_start);
+    newDate.setDate(newDate.getDate() - 7);
+    setcurrent_week_start(newDate);
+    // Update month and year based on the new week
+    setcurrent_month(newDate.getMonth());
+    setcurrent_year(newDate.getFullYear());
   };
 
   const renderDateTiles = () => {
@@ -108,13 +153,23 @@ function Calendar(schedule) {
     }
     // Add tiles for each day
     daysInMonth.forEach((day) => {
-      tiles.push(<DateTile key={day} day={day} events={schedule.events} />);
+      tiles.push(
+        <DateTile
+          key={day}
+          day={day}
+          month={current_month}
+          year={current_year}
+          events={events}
+          onDateClick={onDateTimeClick}
+        />
+      );
     });
     return tiles;
   };
 
   useEffect(() => {
     updateMonthData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [current_month, current_year]);
 
   useEffect(() => {
@@ -124,30 +179,63 @@ function Calendar(schedule) {
         block: 'nearest',
       });
     }
-    console.log('THE FIRST DAY BEH: ', weekdays[first_day]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show_year_dropdown]);
 
+  // Initialize current_week_start to the start of the current week
+  useEffect(() => {
+    const today = new Date();
+    const day = today.getDay();
+    const diff = today.getDate() - day;
+    const sunday = new Date(today.setDate(diff));
+    setcurrent_week_start(sunday);
+  }, []);
+
+  // Handle window resize for responsive behavior
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Cleanup listener on component unmount
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  const weekDates = getWeekDates(current_week_start);
+  const weekStartMonth = weekDates[0].getMonth();
+  const weekEndMonth = weekDates[6].getMonth();
+  const displayMonth =
+    weekStartMonth === weekEndMonth
+      ? monthName[weekStartMonth]
+      : `${monthName[weekStartMonth]} - ${monthName[weekEndMonth]}`;
+
   return (
-    <div>
+    <div className="w-full max-w-7xl mx-auto px-2 md:px-4 lg:px-6">
       <div className="flex justify-center items-center w-full mt-2 flex-col">
-        <div className="items-center w-full mt-4 h-14 px-6 flex flex-row justify-center overflow-visible">
+        <div className="items-center w-full mt-4 min-h-14 px-4 md:px-8 flex flex-col md:flex-row justify-center overflow-visible gap-2 md:gap-0">
           {' '}
           {/*div upper container*/}
-          <button className="mr-[4%] rounded-full p-2 border-none hover:border-slate-500 hover:border hover:bg-slate-300 transition duration-100">
-            <FaGear size={'1.7vw'} />
+          <button className="hidden md:block md:mr-4 rounded-full p-2 border-none hover:border-slate-500 hover:border hover:bg-slate-300 transition duration-100">
+            <FaGear className="text-base md:text-lg lg:text-xl" />
           </button>
-          <div className="mx-4">
+          <div className="mx-2 md:mx-4 relative">
             <button
               onClick={() => {
                 setshow_dropdown(!show_dropdown);
                 setshow_year_dropdown(false);
               }}
-              className="flex justify-between space-x-2 w-36 text-center text-white bg-dark-red-2 hover:bg-dark-red-3 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 items-center"
+              className="flex justify-between space-x-2 w-32 md:w-36 text-center text-white bg-dark-red-2 hover:bg-dark-red-3 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-xs md:text-sm px-3 md:px-5 py-2 md:py-2.5 items-center"
               type="button"
             >
-              {monthName[current_month]}
+              <span className="truncate">
+                {view_mode === 0 ? monthName[current_month] : displayMonth}
+              </span>
               <svg
-                class="w-2.5 h-2.5 ms-3 flex"
+                className="w-2.5 h-2.5 ms-1 flex flex-shrink-0"
                 aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -155,9 +243,9 @@ function Calendar(schedule) {
               >
                 <path
                   stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
                   d="m1 1 4 4 4-4"
                 />
               </svg>
@@ -186,18 +274,18 @@ function Calendar(schedule) {
               </div>
             )}
           </div>
-          <div className="mx-4">
+          <div className="mx-2 md:mx-4 relative">
             <button
               onClick={() => {
                 setshow_year_dropdown(!show_year_dropdown);
                 setshow_dropdown(false);
               }}
-              className="text-center text-white bg-dark-red-2 hover:bg-dark-red-3  dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 inline-flex items-center"
+              className="text-center text-white bg-dark-red-2 hover:bg-dark-red-3  dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-xs md:text-sm px-3 md:px-5 py-2 md:py-2.5 inline-flex items-center"
               type="button"
             >
               {current_year}
               <svg
-                class="w-2.5 h-2.5 ms-3"
+                className="w-2.5 h-2.5 ms-2 md:ms-3"
                 aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -205,9 +293,9 @@ function Calendar(schedule) {
               >
                 <path
                   stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
                   d="m1 1 4 4 4-4"
                 />
               </svg>
@@ -236,41 +324,59 @@ function Calendar(schedule) {
               </div>
             )}
           </div>
-          <div className="mx-[10vw] flex flex-row">
+          <div className="mx-2 md:mx-8 lg:mx-16 flex flex-row">
             <button>
               <MdNavigateBefore
                 onClick={() => {
-                  subMonth();
+                  if (view_mode === 0) {
+                    subMonth();
+                  } else {
+                    subWeek();
+                  }
                 }}
                 className={
-                  'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
+                  'mx-2 md:mx-4 lg:mx-6 rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
                 }
-                size={'1.8vw'}
+                size={windowWidth < 768 ? 24 : 28}
               />
             </button>
             <button>
               <MdNavigateNext
                 onClick={() => {
-                  addMonth();
+                  if (view_mode === 0) {
+                    addMonth();
+                  } else {
+                    addWeek();
+                  }
                 }}
                 className={
-                  'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
+                  'mx-2 md:mx-4 lg:mx-6 rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
                 }
-                size={'1.8vw'}
+                size={windowWidth < 768 ? 24 : 28}
               />
             </button>
           </div>
-          <p className="mr-2 ">View:</p>
-          <div className="flex flex-row items-center w-1/5 h-[5vh] rounded-lg border border-black py-5">
+          <p className="mr-2 text-xs md:text-sm">View:</p>
+          <div className="flex w-fit flex-row items-center rounded-lg border border-black">
             <button
-              // onClick={()=>setmode(0)}
-              className="rounded-tr-none rounded-br-none w-full focus:outline-none border-rad hover:border-none text-white bg-dark-red-2 font-medium rounded-md text-sm px-5 py-2.5"
+              onClick={() => handleViewChange(0)}
+              disabled={isLoadingView}
+              className={`rounded-tr-none rounded-br-none w-full focus:outline-none border-rad hover:border-none font-medium rounded-md text-xs md:text-sm px-2 md:px-5 py-2 md:py-2.5 transition-colors ${
+                view_mode === 0
+                  ? 'text-white bg-dark-red-2'
+                  : 'hover:bg-dark-red-3 hover:text-white text-german-red'
+              } ${isLoadingView ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               Month
             </button>
             <button
-              // onClick={()=>setmode(1)}
-              className="rounded-tl-none rounded-bl-none w-full focus:outline-none hover:bg-dark-red-3 hover:text-white text-german-red font-medium rounded-md text-sm px-5 py-2.5"
+              onClick={() => handleViewChange(1)}
+              disabled={isLoadingView}
+              className={`rounded-tl-none rounded-bl-none w-full focus:outline-none font-medium rounded-md text-xs md:text-sm px-2 md:px-5 py-2 md:py-2.5 transition-colors ${
+                view_mode === 1
+                  ? 'text-white bg-dark-red-2'
+                  : 'hover:bg-dark-red-3 hover:text-white text-german-red'
+              } ${isLoadingView ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               Week
             </button>
@@ -278,15 +384,45 @@ function Calendar(schedule) {
         </div>
         {/*End of Top Section of Calendar*/}
 
-        <div className="flex flex-col justify-center items-center mb-12 mt-2 w-11/12 p-5 border-2 border-black border-solid shadow-lg rounded-lg">
-          <div>
-            <div className="grid grid-cols-7 gap-6 w-full">
-              {weekdays.map((day, index) => (
-                <DaysWeek key={index} day={index} title={day} />
-              ))}
+        <div className="flex flex-col justify-center items-center mb-12 mt-4 w-full px-4 md:px-8 lg:px-12 py-5 border-2 border-black border-solid shadow-lg rounded-lg min-h-[500px]">
+          {isLoadingView ? (
+            <Spinner
+              size="lg"
+              color="text-dark-red-2"
+              message="Switching view..."
+              className="py-20"
+            />
+          ) : view_mode === 0 ? (
+            <div className="w-full">
+              <div className="grid grid-cols-7 gap-2 md:gap-3 lg:gap-4 w-full">
+                {weekdays.map((day, index) => {
+                  let mobileTitle = day.substring(0, 1); // Default to first letter
+                  // Special cases for Thursday and Sunday
+                  if (day === 'Thursday') mobileTitle = 'Th';
+                  if (day === 'Sunday') mobileTitle = 'Su';
+
+                  return (
+                    <DaysWeek
+                      key={index}
+                      day={index}
+                      title={windowWidth < 768 ? mobileTitle : day}
+                    />
+                  );
+                })}
+              </div>
+              <div className="grid grid-cols-7 gap-2 md:gap-3 lg:gap-4">
+                {renderDateTiles()}
+              </div>
             </div>
-            <div className="grid grid-cols-7 gap-6">{renderDateTiles()}</div>
-          </div>
+          ) : (
+            <div className="w-full">
+              <WeekView
+                weekDates={weekDates}
+                events={events}
+                onTimeSlotClick={onDateTimeClick}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/calendar/Calendar.js
+++ b/client/src/components/calendar/Calendar.js
@@ -1,250 +1,296 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { FaGear } from "react-icons/fa6";
-import { MdNavigateBefore, MdNavigateNext } from "react-icons/md";
+import { FaGear } from 'react-icons/fa6';
+import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md';
 import DateTile from '../../components/calendar/DateTile';
 import DaysWeek from './DaysWeek';
 
-function Calendar(props) {
-    const [current_month, setcurrent_month] = useState(new Date().getMonth());
-    const [current_year, setcurrent_year] = useState(new Date().getFullYear());
-    const [number_of_days, setnumber_of_days] = useState(0); 
-    const [show_dropdown, setshow_dropdown] = useState(false);
-    const [show_year_dropdown, setshow_year_dropdown] = useState(false);
-    const current_year_ref = useRef(null);
-    const year_range = Array.from({ length: 21 }, (_, i) => current_year - 10 + i);
-    const [first_day, setfirst_day] = useState(0);
-    const weekdays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-    const monthName = [
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December"
-    ];
+function Calendar(schedule) {
+  const [current_month, setcurrent_month] = useState(new Date().getMonth());
+  const [current_year, setcurrent_year] = useState(new Date().getFullYear());
+  const [number_of_days, setnumber_of_days] = useState(0);
+  const [show_dropdown, setshow_dropdown] = useState(false);
+  const [show_year_dropdown, setshow_year_dropdown] = useState(false);
+  const current_year_ref = useRef(null);
+  const year_range = Array.from(
+    { length: 21 },
+    (_, i) => current_year - 10 + i
+  );
+  const [first_day, setfirst_day] = useState(0);
+  const weekdays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+  const monthName = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
 
-    // const daysInMonth = (month, year) => new Date(year, month, 0).getDate();
-    const daysInMonth = Array.from({ length: number_of_days }, (_, i) => i + 1);
+  // const daysInMonth = (month, year) => new Date(year, month, 0).getDate();
+  const daysInMonth = Array.from({ length: number_of_days }, (_, i) => i + 1);
 
-    const calculateDaysInMonth = (month, year) => {
-        return new Date(year, month, 0).getDate();
-    };
-    
+  const calculateDaysInMonth = (month, year) => {
+    return new Date(year, month, 0).getDate();
+  };
 
-    // Calculate first day of the current month and number of days
-    const updateMonthData = () => {
-        const firstDay = new Date(current_year, current_month, 1).getDay();
-        setfirst_day(firstDay);
-        setnumber_of_days(calculateDaysInMonth(current_month + 1, current_year)); // Use the helper function here
-    };
-    
+  // Calculate first day of the current month and number of days
+  const updateMonthData = () => {
+    const firstDay = new Date(current_year, current_month, 1).getDay();
+    setfirst_day(firstDay);
+    setnumber_of_days(calculateDaysInMonth(current_month + 1, current_year)); // Use the helper function here
+  };
 
-    const addMonth = () => {
-        if (current_month < 11) {
-            setcurrent_month(current_month + 1);
-        } else {
-            setcurrent_month(0);
-            setcurrent_year(current_year + 1);
-        }
-    };
-
-    const subMonth = () => {
-        if (current_month > 0) {
-            setcurrent_month(current_month - 1);
-        } else {
-            setcurrent_month(11);
-            setcurrent_year(current_year - 1);
-        }
-    };
-
-    const changeMonth = (num) => {
-        if (num >= 0 && num < 12) {
-            setcurrent_month(num);
-        } else {
-            setcurrent_month(0);
-        }
-        setshow_dropdown(false);
-    };
-
-    const addYear = () => {
-        setcurrent_year(current_year + 1);
-        setshow_year_dropdown(false);
-    };
-
-    const subYear = () => {
-        setcurrent_year(current_year - 1);
-        setshow_year_dropdown(false);
-    };
-
-    const changeYear = (num) => {
-        if (num >= 1990 && num <= 3000) {
-            setcurrent_year(num);
-        } else {
-            setcurrent_year(new Date().getFullYear());
-        }
-        setshow_year_dropdown(false);
-    };
-
-    const renderDateTiles = () => {
-        const tiles = [];
-        // Add empty tiles for offset (first day of the month)
-        for (let i = 0; i < first_day; i++) {
-            tiles.push(<DateTile key={`empty-${i}`} />);
-        }
-        // Add tiles for each day
-        daysInMonth.forEach((day) => {
-            tiles.push(<DateTile key={day} day={day} />);
-        });
-        return tiles;
-    };
-
-    useEffect(() => {
-        updateMonthData();
-    }, [current_month, current_year]);
-
-    useEffect(() => {
-        if (show_year_dropdown && current_year_ref.current) {
-            current_year_ref.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }
-        console.log("THE FIRST DAY BEH: ",weekdays[first_day])
-    }, [show_year_dropdown]);
-    
-    
-    
-    return (
-        <div>
-            <div className='flex justify-center items-center w-full mt-2 flex-col'>
-                <div className='items-center w-full mt-4 h-14 px-6 flex flex-row justify-center overflow-visible'> {/*div upper container*/}
-                    <button className='mr-[4%] rounded-full p-2 border-none hover:border-slate-500 hover:border hover:bg-slate-300 transition duration-100'><FaGear size={'1.7vw'}/></button>
-                    <div className='mx-4'>
-                        <button onClick={()=>{
-                            setshow_dropdown(!show_dropdown);
-                            setshow_year_dropdown(false);
-                        }}className="flex justify-between space-x-2 w-36 text-center text-white bg-dark-red-2 hover:bg-dark-red-3 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center" 
-                            type="button">
-                                {monthName[current_month]} 
-                                <svg class="w-2.5 h-2.5 ms-3 flex" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-                                </svg>
-                        </button>
-                        {show_dropdown &&
-                        <div class=" absolute z-10 bg-white divide-y divide-gray-100 rounded-lg w-44 dark:bg-gray-700 border border-solid border-neutral-300 shadow">
-                            <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
-                                <li>
-                                    <button onClick={()=>changeMonth(0)} class={`${current_month === 0 ? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>January</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(1)}  class={`${current_month === 1? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>February</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(2)}  class={`${current_month === 2? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>March</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(3)}  class={`${current_month === 3? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>April</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(4)}  class={`${current_month === 4? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>May</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(5)}  class={`${current_month === 5? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>June</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(6)}  class={`${current_month === 6? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>July</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(7)} class={`${current_month === 7? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>August</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(8)} class={`${current_month === 8? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>September</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(9)} class={`${current_month === 9? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>October</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(10)} class={`${current_month === 10? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>November</button>
-                                </li>
-                                <li>
-                                    <button onClick={()=>changeMonth(11)} class={`${current_month === 11? 'bg-dark-red-2 text-white':''} w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}>December</button>
-                                </li>
-                            </ul>
-                        </div>
-                        }
-                    </div>
-                    <div className='mx-4'>
-                        <button onClick={()=>{
-                            setshow_year_dropdown(!show_year_dropdown)
-                            setshow_dropdown(false)
-                        
-                        }}className="text-center text-white bg-dark-red-2 hover:bg-dark-red-3  dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center" 
-                            type="button">
-                                {current_year} 
-                                <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-                                </svg>
-                        </button>
-                        {show_year_dropdown && (
-                            <div className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg w-44 dark:bg-gray-700 border border-solid border-neutral-300 shadow">
-                                <ul
-                                    className="py-2 text-sm text-gray-700 dark:text-gray-200 max-h-64 overflow-y-auto"
-                                    aria-labelledby="dropdownDefaultButton"
-                                >
-                                        {year_range.map((year) => (
-                                        <li 
-                                                key={year}
-                                                ref={year === current_year ? current_year_ref : null}
-                                                onClick={() => changeYear(year)}
-                                                className={`w-full text-start block px-4 py-2 cursor-pointer ${
-                                                year === current_year
-                                                ? 'bg-dark-red-2 text-white'
-                                                : 'hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white'
-                                            }`}
-                                            >
-                                            {year}
-                                        
-                                        </li>
-                                        ))}
-                                </ul>
-                            </div>
-                        )}
-                    </div>
-
-                    <div className='mx-[10vw] flex flex-row'>
-                        <button><MdNavigateBefore onClick={()=>{subMonth()}}className={'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'} size={'1.8vw'}/></button>
-                        <button><MdNavigateNext onClick={()=>{addMonth()}} className={'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'} size={'1.8vw'}/></button>
-                    </div>
-
-                    <p className='mr-2 '>View:</p>
-                    <div className='flex flex-row items-center w-1/5 h-[5vh] rounded-lg border border-black py-5'>
-                        <button 
-                            // onClick={()=>setmode(0)}
-                            className='rounded-tr-none rounded-br-none w-full focus:outline-none border-rad hover:border-none text-white bg-dark-red-2 font-medium rounded-md text-sm px-5 py-2.5'>
-                            Month
-                        </button>
-                        <button 
-                            // onClick={()=>setmode(1)}
-                            className='rounded-tl-none rounded-bl-none w-full focus:outline-none hover:bg-dark-red-3 hover:text-white text-german-red font-medium rounded-md text-sm px-5 py-2.5'>
-                            Week
-                        </button>
-                        
-
-                    </div>
-                </div>
-                {/*End of Top Section of Calendar*/}
-
-                <div className='flex flex-col justify-center items-center mb-12 mt-2 w-11/12 p-5 border-2 border-black border-solid shadow-lg rounded-lg'>
-                    <div >
-                        <div className="grid grid-cols-7 gap-6 w-full">
-                            {weekdays.map((day, index) => (
-                                <DaysWeek key={index} day={index} title={day} />
-                            ))}
-                        </div>
-                        <div className="grid grid-cols-7 gap-6">
-                            {renderDateTiles()}
-                        </div>
-                    </div>
-
-                </div>
-            </div>
-        </div>
-    )
+  const addMonth = () => {
+    if (current_month < 11) {
+      setcurrent_month(current_month + 1);
+    } else {
+      setcurrent_month(0);
+      setcurrent_year(current_year + 1);
     }
+  };
 
-Calendar.propTypes = {}
+  const subMonth = () => {
+    if (current_month > 0) {
+      setcurrent_month(current_month - 1);
+    } else {
+      setcurrent_month(11);
+      setcurrent_year(current_year - 1);
+    }
+  };
 
-export default Calendar
+  const changeMonth = (num) => {
+    if (num >= 0 && num < 12) {
+      setcurrent_month(num);
+    } else {
+      setcurrent_month(0);
+    }
+    setshow_dropdown(false);
+  };
+
+  const addYear = () => {
+    setcurrent_year(current_year + 1);
+    setshow_year_dropdown(false);
+  };
+
+  const subYear = () => {
+    setcurrent_year(current_year - 1);
+    setshow_year_dropdown(false);
+  };
+
+  const changeYear = (num) => {
+    if (num >= 1990 && num <= 3000) {
+      setcurrent_year(num);
+    } else {
+      setcurrent_year(new Date().getFullYear());
+    }
+    setshow_year_dropdown(false);
+  };
+
+  const renderDateTiles = () => {
+    const tiles = [];
+    // Add empty tiles for offset (first day of the month)
+    for (let i = 0; i < first_day; i++) {
+      tiles.push(<DateTile key={`empty-${i}`} />);
+    }
+    // Add tiles for each day
+    daysInMonth.forEach((day) => {
+      tiles.push(<DateTile key={day} day={day} events={schedule.events} />);
+    });
+    return tiles;
+  };
+
+  useEffect(() => {
+    updateMonthData();
+  }, [current_month, current_year]);
+
+  useEffect(() => {
+    if (show_year_dropdown && current_year_ref.current) {
+      current_year_ref.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    }
+    console.log('THE FIRST DAY BEH: ', weekdays[first_day]);
+  }, [show_year_dropdown]);
+
+  return (
+    <div>
+      <div className="flex justify-center items-center w-full mt-2 flex-col">
+        <div className="items-center w-full mt-4 h-14 px-6 flex flex-row justify-center overflow-visible">
+          {' '}
+          {/*div upper container*/}
+          <button className="mr-[4%] rounded-full p-2 border-none hover:border-slate-500 hover:border hover:bg-slate-300 transition duration-100">
+            <FaGear size={'1.7vw'} />
+          </button>
+          <div className="mx-4">
+            <button
+              onClick={() => {
+                setshow_dropdown(!show_dropdown);
+                setshow_year_dropdown(false);
+              }}
+              className="flex justify-between space-x-2 w-36 text-center text-white bg-dark-red-2 hover:bg-dark-red-3 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 items-center"
+              type="button"
+            >
+              {monthName[current_month]}
+              <svg
+                class="w-2.5 h-2.5 ms-3 flex"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 10 6"
+              >
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="m1 1 4 4 4-4"
+                />
+              </svg>
+            </button>
+            {show_dropdown && (
+              <div className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg w-44 dark:bg-gray-700 border border-solid border-neutral-300 shadow">
+                <ul
+                  className="py-2 text-sm text-gray-700 dark:text-gray-200"
+                  aria-labelledby="dropdownDefaultButton"
+                >
+                  {monthName.map((month, index) => (
+                    <li key={month}>
+                      <button
+                        onClick={() => changeMonth(index)}
+                        className={`${
+                          current_month === index
+                            ? 'bg-dark-red-2 text-white'
+                            : ''
+                        } w-full text-start block px-4 py-2 hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white`}
+                      >
+                        {month}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+          <div className="mx-4">
+            <button
+              onClick={() => {
+                setshow_year_dropdown(!show_year_dropdown);
+                setshow_dropdown(false);
+              }}
+              className="text-center text-white bg-dark-red-2 hover:bg-dark-red-3  dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900  focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 inline-flex items-center"
+              type="button"
+            >
+              {current_year}
+              <svg
+                class="w-2.5 h-2.5 ms-3"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 10 6"
+              >
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="m1 1 4 4 4-4"
+                />
+              </svg>
+            </button>
+            {show_year_dropdown && (
+              <div className="absolute z-10 bg-white divide-y divide-gray-100 rounded-lg w-44 dark:bg-gray-700 border border-solid border-neutral-300 shadow">
+                <ul
+                  className="py-2 text-sm text-gray-700 dark:text-gray-200 max-h-64 overflow-y-auto"
+                  aria-labelledby="dropdownDefaultButton"
+                >
+                  {year_range.map((year) => (
+                    <li
+                      key={year}
+                      ref={year === current_year ? current_year_ref : null}
+                      onClick={() => changeYear(year)}
+                      className={`w-full text-start block px-4 py-2 cursor-pointer ${
+                        year === current_year
+                          ? 'bg-dark-red-2 text-white'
+                          : 'hover:bg-dark-red-2 hover:text-white dark:hover:bg-gray-600 dark:hover:text-white'
+                      }`}
+                    >
+                      {year}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+          <div className="mx-[10vw] flex flex-row">
+            <button>
+              <MdNavigateBefore
+                onClick={() => {
+                  subMonth();
+                }}
+                className={
+                  'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
+                }
+                size={'1.8vw'}
+              />
+            </button>
+            <button>
+              <MdNavigateNext
+                onClick={() => {
+                  addMonth();
+                }}
+                className={
+                  'mx-[3vw] rounded-full hover:bg-german-red hover:bg-opacity-35 transition duration-100'
+                }
+                size={'1.8vw'}
+              />
+            </button>
+          </div>
+          <p className="mr-2 ">View:</p>
+          <div className="flex flex-row items-center w-1/5 h-[5vh] rounded-lg border border-black py-5">
+            <button
+              // onClick={()=>setmode(0)}
+              className="rounded-tr-none rounded-br-none w-full focus:outline-none border-rad hover:border-none text-white bg-dark-red-2 font-medium rounded-md text-sm px-5 py-2.5"
+            >
+              Month
+            </button>
+            <button
+              // onClick={()=>setmode(1)}
+              className="rounded-tl-none rounded-bl-none w-full focus:outline-none hover:bg-dark-red-3 hover:text-white text-german-red font-medium rounded-md text-sm px-5 py-2.5"
+            >
+              Week
+            </button>
+          </div>
+        </div>
+        {/*End of Top Section of Calendar*/}
+
+        <div className="flex flex-col justify-center items-center mb-12 mt-2 w-11/12 p-5 border-2 border-black border-solid shadow-lg rounded-lg">
+          <div>
+            <div className="grid grid-cols-7 gap-6 w-full">
+              {weekdays.map((day, index) => (
+                <DaysWeek key={index} day={index} title={day} />
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-6">{renderDateTiles()}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Calendar;

--- a/client/src/components/calendar/DateTile.js
+++ b/client/src/components/calendar/DateTile.js
@@ -5,19 +5,19 @@ import TileEvent from './TileEvent';
 // Replace with logic of getting the events of that day
 const defaultEvents = [
   {
-    title: "A1: Basic German Course",
-    time: "10:00 AM",
-    color: "#FFCF00"
+    title: 'A1: Basic German Course',
+    time: '10:00 AM',
+    color: '#FFCF00',
   },
   {
-    title: "A1: Basic German Course",
-    time: "1:30 PM",
-    color: "#0099FF"
+    title: 'A1: Basic German Course',
+    time: '1:30 PM',
+    color: '#0099FF',
   },
   {
-    title: "A2: Basic German Course",
-    time: "1:30 PM",
-    color: "#29CC6A"
+    title: 'A2: Basic German Course',
+    time: '1:30 PM',
+    color: '#29CC6A',
   },
 ];
 
@@ -25,7 +25,7 @@ function DateTile({ day = null, events = defaultEvents }) {
   // Handle blank tiles (day === null)
   if (day === null) {
     return (
-      <div className="flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400">
+      <div className="hover:cursor-pointer flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100">
         {/* Blank tile */}
       </div>
     );
@@ -33,7 +33,7 @@ function DateTile({ day = null, events = defaultEvents }) {
 
   // Handle populated tiles
   return (
-    <div className="flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400 min-h-[120px] max-h-[120px] overflow-hidden">
+    <div className="hover:cursor-pointer flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100 min-h-[120px] max-h-[120px] overflow-hidden">
       <p className="text-base font-bold">{day}</p>
       <div className="overflow-hidden">
         <div></div>
@@ -48,7 +48,7 @@ function DateTile({ day = null, events = defaultEvents }) {
 // Define PropTypes
 DateTile.propTypes = {
   day: PropTypes.number, // Day number or null for blank tiles
-  events: PropTypes.array // List of event objects
+  events: PropTypes.array, // List of event objects
 };
 
 // Export component

--- a/client/src/components/calendar/DateTile.js
+++ b/client/src/components/calendar/DateTile.js
@@ -1,45 +1,103 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import TileEvent from './TileEvent';
+import { getEventsForDate } from '../../utils/scheduleUtils';
 
 // Replace with logic of getting the events of that day
 const defaultEvents = [
   {
     title: 'A1: Basic German Course',
-    time: '10:00 AM',
+    days: 'M,W,F',
+    time_start: '10:00 AM',
+    time_end: '11:00 AM',
     color: '#FFCF00',
+    periodStart: '2025-09-01',
+    periodEnd: '2025-12-15',
+    periodName: 'Fall 2025',
   },
   {
     title: 'A1: Basic German Course',
-    time: '1:30 PM',
+    days: 'T,TH',
+    time_start: '1:30 PM',
+    time_end: '2:30 PM',
     color: '#0099FF',
+    periodStart: '2025-09-01',
+    periodEnd: '2025-12-15',
+    periodName: 'Fall 2025',
   },
   {
     title: 'A2: Basic German Course',
-    time: '1:30 PM',
+    days: 'T,TH',
+    time_start: '1:30 PM',
+    time_end: '2:30 PM',
     color: '#29CC6A',
+    periodStart: '2025-09-01',
+    periodEnd: '2025-12-15',
+    periodName: 'Fall 2025',
   },
 ];
 
-function DateTile({ day = null, events = defaultEvents }) {
+function DateTile({
+  day = null,
+  month,
+  year,
+  events = defaultEvents,
+  onDateClick,
+}) {
   // Handle blank tiles (day === null)
   if (day === null) {
     return (
-      <div className="hover:cursor-pointer flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100">
+      <div className="hover:cursor-pointer flex flex-col m-0.5 md:m-2 rounded-md p-1 md:p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100">
         {/* Blank tile */}
       </div>
     );
   }
 
+  // Filter events that occur on this day of the week
+  const currentDate = new Date(year, month, day);
+  const filteredEvents = getEventsForDate(events, currentDate);
+
+  const handleClick = () => {
+    if (onDateClick) {
+      onDateClick(currentDate, filteredEvents);
+    }
+  };
+
   // Handle populated tiles
   return (
-    <div className="hover:cursor-pointer flex flex-col m-2 rounded-md p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100 min-h-[120px] max-h-[120px] overflow-hidden">
-      <p className="text-base font-bold">{day}</p>
-      <div className="overflow-hidden">
-        <div></div>
-        {events.map((event, index) => (
+    <div
+      onClick={handleClick}
+      className="w-full hover:cursor-pointer flex flex-col m-0.5 md:m-2 rounded-md p-1 md:p-2 border-solid border-2 border-neutral-400 hover:border-red-700 duration-100 min-h-[80px] md:min-h-[120px] max-h-[80px] md:max-h-[120px] overflow-hidden"
+    >
+      <p className="text-sm md:text-base font-bold">{day}</p>
+
+      {/* Mobile view: Show only dots */}
+      <div className="md:hidden flex flex-wrap gap-1">
+        {filteredEvents.slice(0, 6).map((event, index) => (
+          <div
+            key={index}
+            style={{ backgroundColor: event.color }}
+            className="w-2 h-2 rounded-full"
+            title={event.courseName || event.title}
+          />
+        ))}
+        {filteredEvents.length > 6 && (
+          <span className="text-[8px] text-gray-600 font-semibold ml-1">
+            +{filteredEvents.length - 6}
+          </span>
+        )}
+      </div>
+
+      {/* Desktop view: Show full event details */}
+      <div className="hidden md:block overflow-hidden space-y-1">
+        {filteredEvents.slice(0, 3).map((event, index) => (
           <TileEvent key={index} event={event} />
         ))}
+        {filteredEvents.length > 3 && (
+          <p className="text-[10px] text-gray-600 font-semibold">
+            +{filteredEvents.length - 3} more
+          </p>
+        )}
       </div>
     </div>
   );
@@ -48,7 +106,22 @@ function DateTile({ day = null, events = defaultEvents }) {
 // Define PropTypes
 DateTile.propTypes = {
   day: PropTypes.number, // Day number or null for blank tiles
-  events: PropTypes.array, // List of event objects
+  month: PropTypes.number, // Month (0-11)
+  year: PropTypes.number, // Full year
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string, // For backward compatibility
+      courseName: PropTypes.string, // Preferred field
+      days: PropTypes.string.isRequired, // e.g., "M,W,F" or "T,TH"
+      time_start: PropTypes.string.isRequired,
+      time_end: PropTypes.string,
+      color: PropTypes.string.isRequired,
+      periodStart: PropTypes.string, // Academic period start date
+      periodEnd: PropTypes.string, // Academic period end date
+      periodName: PropTypes.string, // e.g., "Fall 2025"
+    })
+  ),
+  onDateClick: PropTypes.func, // Callback when date is clicked
 };
 
 // Export component

--- a/client/src/components/calendar/DaysWeek.js
+++ b/client/src/components/calendar/DaysWeek.js
@@ -10,7 +10,9 @@ function DaysWeek({ day = 1, title = 'Day' }) {
     <div
       className={`flex flex-col m-0.5 md:m-2 rounded-xl md:rounded-3xl p-1 md:p-2 items-center justify-center border-solid border-2 border-neutral-400`}
     >
-      <p className="text-xs md:text-base lg:text-lg font-bold">{title}</p>
+      <p className="text-[0.7rem] md:text-[0.8rem] lg:text-sm font-bold">
+        {title}
+      </p>
     </div>
   );
 }

--- a/client/src/components/calendar/DaysWeek.js
+++ b/client/src/components/calendar/DaysWeek.js
@@ -1,22 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-function DaysWeek({ day = 1, title = "Day" }) {
-  
+function DaysWeek({ day = 1, title = 'Day' }) {
   if (day <= -1) {
     return null;
   }
-  
+
   return (
-    <div className={`flex flex-col m-2 rounded-3xl p-2 items-center justify-center border-solid border-2 border-neutral-400`}>
-        <p className='text-l font-bold'>{title}</p>
+    <div
+      className={`flex flex-col m-0.5 md:m-2 rounded-xl md:rounded-3xl p-1 md:p-2 items-center justify-center border-solid border-2 border-neutral-400`}
+    >
+      <p className="text-xs md:text-base lg:text-lg font-bold">{title}</p>
     </div>
-  )
+  );
 }
 
 DaysWeek.propTypes = {
-    day: PropTypes.number,
-    title: PropTypes.string,
-  };
+  day: PropTypes.number,
+  title: PropTypes.string,
+};
 
-export default DaysWeek
+export default DaysWeek;

--- a/client/src/components/calendar/TileEvent.js
+++ b/client/src/components/calendar/TileEvent.js
@@ -2,17 +2,24 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 function TileEvent({ event }) {
+  // Support both courseName and title for backward compatibility
+  const displayTitle = event.courseName || event.title;
+
   return (
     <div
       style={{ backgroundColor: event.color }}
       className="w-full min-h-[20px] max-h-[30px] px-1 rounded-md overflow-hidden flex items-center"
     >
       <span className="font-bold text-[8px] sm:text-[6px] md:text-[7px] lg:text-[7px] xl:text-[12px] text-ellipsis whitespace-nowrap">
-        {event.time + ' '}
+        {event.time_start + ' - '}
       </span>
-      -{' '}
+      {event.time_end && (
+        <span className="font-bold text-[8px] sm:text-[6px] md:text-[7px] lg:text-[7px] xl:text-[12px] text-ellipsis whitespace-nowrap">
+          {event.time_end + ' - '}
+        </span>
+      )}
       <span className="text-[8px] sm:text-[6px] md:text-[7px] lg:text-[7px] xl:text-[12px] overflow-hidden text-ellipsis whitespace-nowrap">
-        {event.title}
+        {displayTitle}
       </span>
     </div>
   );
@@ -20,8 +27,10 @@ function TileEvent({ event }) {
 
 TileEvent.propTypes = {
   event: PropTypes.shape({
-    time: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
+    time_start: PropTypes.string.isRequired,
+    time_end: PropTypes.string,
+    title: PropTypes.string, // For backward compatibility
+    courseName: PropTypes.string, // Preferred field
     color: PropTypes.string.isRequired,
   }),
 };

--- a/client/src/components/calendar/WeekView.js
+++ b/client/src/components/calendar/WeekView.js
@@ -1,0 +1,182 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import TileEvent from './TileEvent';
+import { getEventsForTimeSlot as getEventsForTimeSlotUtil } from '../../utils/scheduleUtils';
+
+function WeekView({ weekDates, events = [], onTimeSlotClick }) {
+  const weekdays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+
+  const timeSlots = [
+    '6:00 AM',
+    '7:00 AM',
+    '8:00 AM',
+    '9:00 AM',
+    '10:00 AM',
+    '11:00 AM',
+    '12:00 PM',
+    '1:00 PM',
+    '2:00 PM',
+    '3:00 PM',
+    '4:00 PM',
+    '5:00 PM',
+    '6:00 PM',
+    '7:00 PM',
+    '8:00 PM',
+    '9:00 PM',
+  ];
+
+  const isToday = (date) => {
+    const today = new Date();
+    return (
+      date.getDate() === today.getDate() &&
+      date.getMonth() === today.getMonth() &&
+      date.getFullYear() === today.getFullYear()
+    );
+  };
+
+  const getEventsForTimeSlot = (timeSlot, date) => {
+    return getEventsForTimeSlotUtil(events, timeSlot, date);
+  };
+
+  return (
+    <div className="w-full overflow-x-auto">
+      {/* Week Header - Desktop */}
+      <div className="hidden md:grid md:grid-cols-8 gap-2 mb-4 sticky top-0 bg-white z-0">
+        <div className="p-2"></div> {/* Empty cell for time column */}
+        {weekDates.map((date, index) => (
+          <div
+            key={index}
+            className={`flex flex-col items-center justify-center p-3 rounded-lg border-2 ${
+              isToday(date)
+                ? 'bg-dark-red-2 text-white border-dark-red-3'
+                : 'border-neutral-300 bg-gray-50'
+            }`}
+          >
+            <p className="text-xs font-semibold">{weekdays[date.getDay()]}</p>
+            <p
+              className={`text-2xl font-bold ${
+                isToday(date) ? 'text-white' : ''
+              }`}
+            >
+              {date.getDate()}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Week Header - Mobile (Horizontal Scroll) */}
+      <div className="md:hidden flex overflow-x-auto gap-2 mb-4 pb-2 snap-x snap-mandatory">
+        {weekDates.map((date, index) => (
+          <div
+            key={index}
+            className={`flex-shrink-0 w-20 flex flex-col items-center justify-center p-3 rounded-lg border-2 snap-center ${
+              isToday(date)
+                ? 'bg-dark-red-2 text-white border-dark-red-3'
+                : 'border-neutral-300 bg-gray-50'
+            }`}
+          >
+            <p className="text-xs font-semibold">
+              {weekdays[date.getDay()].substring(0, 3)}
+            </p>
+            <p
+              className={`text-xl font-bold ${
+                isToday(date) ? 'text-white' : ''
+              }`}
+            >
+              {date.getDate()}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Time Grid - Desktop */}
+      <div className="hidden md:block">
+        {timeSlots.map((time, timeIndex) => (
+          <div key={timeIndex} className="grid grid-cols-8 gap-2 mb-2">
+            <div className="p-2 text-sm font-semibold text-gray-600 text-right">
+              {time}
+            </div>
+            {weekDates.map((date, dayIndex) => {
+              const eventsForSlot = getEventsForTimeSlot(time, date);
+              return (
+                <div
+                  key={dayIndex}
+                  onClick={() =>
+                    onTimeSlotClick && onTimeSlotClick(date, eventsForSlot)
+                  }
+                  className="border-2 border-neutral-200 rounded-md p-2 min-h-[80px] hover:border-red-700 hover:bg-gray-50 transition-colors duration-100 cursor-pointer"
+                >
+                  {eventsForSlot.map((event, eventIndex) => (
+                    <TileEvent key={eventIndex} event={event} />
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile Day View */}
+      <div className="md:hidden space-y-4">
+        {weekDates.map((date, dayIndex) => (
+          <div
+            key={dayIndex}
+            className="border-2 border-neutral-300 rounded-lg p-3"
+          >
+            <h3 className="font-bold text-lg mb-3 text-dark-red-2">
+              {weekdays[date.getDay()]}, {date.getDate()}
+            </h3>
+            <div className="space-y-2">
+              {timeSlots.map((time, timeIndex) => {
+                const eventsForSlot = getEventsForTimeSlot(time, date);
+                return (
+                  <div
+                    key={timeIndex}
+                    className="flex items-start border-b border-neutral-200 pb-2"
+                  >
+                    <div className="w-20 text-xs font-semibold text-gray-600 pt-1">
+                      {time}
+                    </div>
+                    <div className="flex-1 min-h-[40px] space-y-1">
+                      {eventsForSlot.map((event, eventIndex) => (
+                        <TileEvent key={eventIndex} event={event} />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+WeekView.propTypes = {
+  weekDates: PropTypes.arrayOf(PropTypes.instanceOf(Date)).isRequired,
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string, // For backward compatibility
+      courseName: PropTypes.string, // Preferred field
+      days: PropTypes.string.isRequired, // e.g., "M,W,F" or "T,TH"
+      time_start: PropTypes.string.isRequired,
+      time_end: PropTypes.string,
+      color: PropTypes.string.isRequired,
+      periodStart: PropTypes.string, // Academic period start date
+      periodEnd: PropTypes.string, // Academic period end date
+      periodName: PropTypes.string, // e.g., "Fall 2025"
+    })
+  ),
+  onTimeSlotClick: PropTypes.func, // Callback when time slot is clicked
+};
+
+export default WeekView;

--- a/client/src/components/common/Spinner.js
+++ b/client/src/components/common/Spinner.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Reusable Spinner Component
+ *
+ * @param {string} size - Size of spinner: 'sm', 'md', 'lg', 'xl'
+ * @param {string} color - Color classes for the spinner
+ * @param {string} message - Optional loading message to display
+ * @param {string} className - Additional CSS classes
+ */
+function Spinner({
+  size = 'md',
+  color = 'text-dark-red-2',
+  message = '',
+  className = '',
+}) {
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-8 w-8',
+    lg: 'h-12 w-12',
+    xl: 'h-16 w-16',
+  };
+
+  const spinnerSize = sizeClasses[size] || sizeClasses.md;
+
+  return (
+    <div className={`flex flex-col items-center justify-center ${className}`}>
+      <svg
+        className={`animate-spin ${spinnerSize} ${color}`}
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        ></circle>
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+      {message && (
+        <p className={`mt-3 text-sm font-medium ${color}`}>{message}</p>
+      )}
+    </div>
+  );
+}
+
+Spinner.propTypes = {
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+  color: PropTypes.string,
+  message: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default Spinner;

--- a/client/src/components/inputs/AcademicPeriodSelect.js
+++ b/client/src/components/inputs/AcademicPeriodSelect.js
@@ -1,0 +1,197 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { MdSearch, MdExpandMore } from 'react-icons/md';
+
+/**
+ * Searchable Academic Period Select Component
+ * Allows searching academic periods by name, id, or dates with dropdown selection
+ */
+function AcademicPeriodSelect({ value, onChange, academicPeriods, isLoading }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const dropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Filter academic periods based on search term
+  const filteredPeriods = academicPeriods.filter((period) => {
+    if (!searchTerm) return true;
+
+    const searchLower = searchTerm.toLowerCase();
+    const periodName = period.periodName?.toLowerCase() || '';
+    const periodId = period.id?.toLowerCase() || '';
+    const batchName = period.batchName?.toLowerCase() || '';
+
+    return (
+      periodName.includes(searchLower) ||
+      periodId.includes(searchLower) ||
+      batchName.includes(searchLower)
+    );
+  });
+
+  // Get selected academic period details
+  const selectedPeriod = academicPeriods.find((p) => p.id === value);
+
+  const handleSelect = (period) => {
+    onChange(period);
+    setIsOpen(false);
+    setSearchTerm('');
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getDisplayName = (period) => {
+    if (!period) return 'Select academic period...';
+    return `${period.periodName}${
+      period.batchName ? ` - ${period.batchName}` : ''
+    }`;
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Selected Period Display / Dropdown Trigger */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-3 py-2 border border-gray-300 rounded bg-white text-left flex items-center justify-between hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+      >
+        <span className={selectedPeriod ? 'text-gray-900' : 'text-gray-400'}>
+          {getDisplayName(selectedPeriod)}
+        </span>
+        <MdExpandMore
+          className={`text-gray-400 transition-transform ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          size={20}
+        />
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg max-h-96 overflow-hidden">
+          {/* Search Input */}
+          <div className="p-2 border-b border-gray-200 sticky top-0 bg-white">
+            <div className="relative">
+              <MdSearch
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+                size={20}
+              />
+              <input
+                type="text"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search by name or ID..."
+                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2 text-sm"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          {/* Academic Periods List */}
+          <div className="overflow-y-auto max-h-80">
+            {isLoading ? (
+              <div className="p-4 text-center text-gray-500">
+                Loading academic periods...
+              </div>
+            ) : filteredPeriods.length === 0 ? (
+              <div className="p-4 text-center text-gray-500">
+                No academic periods found
+              </div>
+            ) : (
+              filteredPeriods.map((period) => (
+                <button
+                  key={period.id}
+                  type="button"
+                  onClick={() => handleSelect(period)}
+                  className={`w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 ${
+                    selectedPeriod?.id === period.id
+                      ? 'bg-dark-red-2 bg-opacity-10 text-dark-red-2 font-medium'
+                      : 'text-gray-700'
+                  }`}
+                >
+                  <div className="flex flex-col">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">
+                        {period.periodName}
+                        {period.batchName && ` - ${period.batchName}`}
+                      </span>
+                      {period.status && (
+                        <span
+                          className={`text-xs px-2 py-1 rounded-full whitespace-nowrap ${
+                            period.status === 'Ongoing'
+                              ? 'bg-green-100 text-green-700'
+                              : period.status.startsWith('Ongoing')
+                              ? 'bg-yellow-100 text-yellow-700'
+                              : period.status === 'Upcoming'
+                              ? 'bg-blue-100 text-blue-700'
+                              : period.status.startsWith('Upcoming')
+                              ? 'bg-orange-100 text-orange-700'
+                              : 'bg-gray-100 text-gray-600'
+                          }`}
+                        >
+                          {period.status}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-sm text-gray-500">
+                        ID: {period.id}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-xs text-gray-500">
+                        {formatDate(period.startAt)} -{' '}
+                        {formatDate(period.endAt)}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+AcademicPeriodSelect.propTypes = {
+  value: PropTypes.string, // Selected academic period ID
+  onChange: PropTypes.func.isRequired, // Callback with selected period object
+  academicPeriods: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      periodName: PropTypes.string.isRequired,
+      batchName: PropTypes.string,
+      startAt: PropTypes.string.isRequired,
+      endAt: PropTypes.string.isRequired,
+      status: PropTypes.string,
+    })
+  ).isRequired,
+  isLoading: PropTypes.bool,
+};
+
+AcademicPeriodSelect.defaultProps = {
+  value: null,
+  isLoading: false,
+};
+
+export default AcademicPeriodSelect;

--- a/client/src/components/inputs/CourseSelect.js
+++ b/client/src/components/inputs/CourseSelect.js
@@ -1,0 +1,156 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { MdSearch, MdExpandMore } from 'react-icons/md';
+
+/**
+ * Searchable Course Select Component
+ * Allows searching courses by name or ID with dropdown selection
+ */
+function CourseSelect({ value, onChange, courses, isLoading }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const dropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Filter courses based on search term
+  const filteredCourses = courses.filter((course) => {
+    if (!searchTerm) return true;
+
+    const searchLower = searchTerm.toLowerCase();
+    const courseName = course.name?.toLowerCase() || '';
+    const courseId = course.id?.toLowerCase() || '';
+
+    return courseName.includes(searchLower) || courseId.includes(searchLower);
+  });
+
+  // Get selected course details
+  const selectedCourse = courses.find((c) => c.id === value);
+
+  const handleSelect = (course) => {
+    onChange(course);
+    setIsOpen(false);
+    setSearchTerm('');
+  };
+
+  const getDisplayName = (course) => {
+    if (!course) return 'Select course...';
+    return course.name;
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Selected Course Display / Dropdown Trigger */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-3 py-2 border border-gray-300 rounded bg-white text-left flex items-center justify-between hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+      >
+        <span className={selectedCourse ? 'text-gray-900' : 'text-gray-400'}>
+          {getDisplayName(selectedCourse)}
+        </span>
+        <MdExpandMore
+          className={`text-gray-400 transition-transform ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          size={20}
+        />
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg max-h-80 overflow-hidden">
+          {/* Search Input */}
+          <div className="p-2 border-b border-gray-200 sticky top-0 bg-white">
+            <div className="relative">
+              <MdSearch
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+                size={20}
+              />
+              <input
+                type="text"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search by course name..."
+                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2 text-sm"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          {/* Courses List */}
+          <div className="overflow-y-auto max-h-64">
+            {isLoading ? (
+              <div className="p-4 text-center text-gray-500">
+                Loading courses...
+              </div>
+            ) : filteredCourses.length === 0 ? (
+              <div className="p-4 text-center text-gray-500">
+                No courses found
+              </div>
+            ) : (
+              filteredCourses.map((course) => (
+                <button
+                  key={course.id}
+                  type="button"
+                  onClick={() => handleSelect(course)}
+                  className={`w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 ${
+                    selectedCourse?.id === course.id
+                      ? 'bg-dark-red-2 bg-opacity-10 text-dark-red-2 font-medium'
+                      : 'text-gray-700'
+                  }`}
+                >
+                  <div className="flex flex-col">
+                    <span className="font-medium">{course.name}</span>
+                    {course.description && (
+                      <span className="text-sm text-gray-500 truncate">
+                        {course.description}
+                      </span>
+                    )}
+                    {course.price && (
+                      <span className="text-xs text-gray-400 mt-1">
+                        Price: ${parseFloat(course.price).toFixed(2)}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+CourseSelect.propTypes = {
+  value: PropTypes.string, // Selected course ID
+  onChange: PropTypes.func.isRequired, // Callback with selected course object
+  courses: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      visibility: PropTypes.string,
+    })
+  ).isRequired,
+  isLoading: PropTypes.bool,
+};
+
+CourseSelect.defaultProps = {
+  value: null,
+  isLoading: false,
+};
+
+export default CourseSelect;

--- a/client/src/components/inputs/TeacherSelect.js
+++ b/client/src/components/inputs/TeacherSelect.js
@@ -1,0 +1,153 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { MdSearch, MdExpandMore } from 'react-icons/md';
+
+/**
+ * Searchable Teacher Select Component
+ * Allows searching teachers by name or ID with dropdown selection
+ */
+function TeacherSelect({ value, onChange, teachers, isLoading }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const dropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Filter teachers based on search term
+  const filteredTeachers = teachers.filter((teacher) => {
+    if (!searchTerm) return true;
+
+    const searchLower = searchTerm.toLowerCase();
+    const fullName = `${teacher.firstName} ${teacher.lastName}`.toLowerCase();
+    const userId = teacher.userId?.toLowerCase() || '';
+
+    return fullName.includes(searchLower) || userId.includes(searchLower);
+  });
+
+  // Get selected teacher details
+  const selectedTeacher = teachers.find((t) => t.id === value);
+
+  const handleSelect = (teacher) => {
+    onChange(teacher);
+    setIsOpen(false);
+    setSearchTerm('');
+  };
+
+  const getDisplayName = (teacher) => {
+    if (!teacher) return 'Select teacher...';
+    return `${teacher.firstName} ${teacher.lastName}`;
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Selected Teacher Display / Dropdown Trigger */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-3 py-2 border border-gray-300 rounded bg-white text-left flex items-center justify-between hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+      >
+        <span className={selectedTeacher ? 'text-gray-900' : 'text-gray-400'}>
+          {getDisplayName(selectedTeacher)}
+        </span>
+        <MdExpandMore
+          className={`text-gray-400 transition-transform ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          size={20}
+        />
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="absolute top-full z-50 w-full mt-1 bg-white border border-gray-500 rounded-lg shadow-lg max-h-80 overflow-hidden">
+          {/* Search Input */}
+          <div className="p-2 border-b border-gray-200 sticky top-0 bg-white">
+            <div className="relative">
+              <MdSearch
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+                size={20}
+              />
+              <input
+                type="text"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search by name or ID..."
+                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2 text-sm"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          {/* Teachers List */}
+          <div className="overflow-y-auto max-h-64">
+            {isLoading ? (
+              <div className="p-4 text-center text-gray-500">
+                Loading teachers...
+              </div>
+            ) : filteredTeachers.length === 0 ? (
+              <div className="p-4 text-center text-gray-500">
+                No teachers found
+              </div>
+            ) : (
+              filteredTeachers.map((teacher) => (
+                <button
+                  key={teacher.id}
+                  type="button"
+                  onClick={() => handleSelect(teacher)}
+                  className={`w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 ${
+                    selectedTeacher?.id === teacher.id
+                      ? 'bg-dark-red-2 bg-opacity-10 text-dark-red-2 font-medium'
+                      : 'text-gray-700'
+                  }`}
+                >
+                  <div className="flex flex-col">
+                    <span className="font-medium">
+                      {teacher.firstName} {teacher.lastName}
+                    </span>
+                    <span className="text-sm text-gray-500">
+                      ID: {teacher.userId}
+                      {teacher.email && ` • ${teacher.email}`}
+                    </span>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+TeacherSelect.propTypes = {
+  value: PropTypes.string, // Selected teacher ID
+  onChange: PropTypes.func.isRequired, // Callback with selected teacher object
+  teachers: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      userId: PropTypes.string.isRequired,
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      email: PropTypes.string,
+      status: PropTypes.string,
+    })
+  ).isRequired,
+  isLoading: PropTypes.bool,
+};
+
+TeacherSelect.defaultProps = {
+  value: null,
+  isLoading: false,
+};
+
+export default TeacherSelect;

--- a/client/src/components/inputs/TeacherSelect.js
+++ b/client/src/components/inputs/TeacherSelect.js
@@ -69,7 +69,7 @@ function TeacherSelect({ value, onChange, teachers, isLoading }) {
 
       {/* Dropdown Menu */}
       {isOpen && (
-        <div className="absolute top-full z-50 w-full mt-1 bg-white border border-gray-500 rounded-lg shadow-lg max-h-80 overflow-hidden">
+        <div className="absolute bottom-full mb-1 z-50 w-full mt-1 bg-white border border-gray-500 rounded-lg shadow-lg max-h-80 overflow-hidden">
           {/* Search Input */}
           <div className="p-2 border-b border-gray-200 sticky top-0 bg-white">
             <div className="relative">

--- a/client/src/components/modals/common/EditPasswordModal.js
+++ b/client/src/components/modals/common/EditPasswordModal.js
@@ -1,14 +1,10 @@
 import React, { useState } from 'react';
 import Swal from 'sweetalert2';
-import { getCookieItem } from '../../../utils/jwt';
 import axiosInstance from '../../../utils/axios';
 import useAuthStore from '../../../stores/authStore';
 import { BsEye, BsEyeSlash } from 'react-icons/bs';
 
-const EditPasswordModal = ({
-  edit_password_modal,
-  setEditPasswordModal
-}) => {
+const EditPasswordModal = ({ edit_password_modal, setEditPasswordModal }) => {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmNewPassword, setConfirmNewPassword] = useState('');
@@ -73,8 +69,8 @@ const EditPasswordModal = ({
       console.error('Something went wrong!', error);
       setError(
         error.response?.data?.message ||
-        error.message ||
-        'Something went wrong!'
+          error.message ||
+          'Something went wrong!'
       );
     } finally {
       setIsLoading(false);
@@ -97,7 +93,10 @@ const EditPasswordModal = ({
         confirmButtonColor: '#6b7280',
         cancelButtonColor: '#992525',
       }).then((result) => {
-        if (result.isDismissed || result.dismiss === Swal.DismissReason.cancel) {
+        if (
+          result.isDismissed ||
+          result.dismiss === Swal.DismissReason.cancel
+        ) {
           setCurrentPassword('');
           setNewPassword('');
           setConfirmNewPassword('');
@@ -158,7 +157,11 @@ const EditPasswordModal = ({
                   className="absolute top-1/2 right-3 transform -translate-y-1/2 text-gray-700 hover:text-dark-red-2 transition-colors duration-150 focus:outline-none"
                   onClick={() => setShowCurrentPassword(!showCurrentPassword)}
                 >
-                  {showCurrentPassword ? <BsEye size={18} /> : <BsEyeSlash size={18} />}
+                  {showCurrentPassword ? (
+                    <BsEye size={18} />
+                  ) : (
+                    <BsEyeSlash size={18} />
+                  )}
                 </button>
               </div>
             </div>
@@ -186,7 +189,11 @@ const EditPasswordModal = ({
                   className="absolute top-1/2 right-3 transform -translate-y-1/2 text-gray-700 hover:text-dark-red-2 transition-colors duration-150 focus:outline-none"
                   onClick={() => setShowNewPassword(!showNewPassword)}
                 >
-                  {showNewPassword ? <BsEye size={18} /> : <BsEyeSlash size={18} />}
+                  {showNewPassword ? (
+                    <BsEye size={18} />
+                  ) : (
+                    <BsEyeSlash size={18} />
+                  )}
                 </button>
               </div>
             </div>
@@ -214,7 +221,11 @@ const EditPasswordModal = ({
                   className="absolute top-1/2 right-3 transform -translate-y-1/2 text-gray-700 hover:text-dark-red-2 transition-colors duration-150 focus:outline-none"
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
-                  {showConfirmPassword ? <BsEye size={18} /> : <BsEyeSlash size={18} />}
+                  {showConfirmPassword ? (
+                    <BsEye size={18} />
+                  ) : (
+                    <BsEyeSlash size={18} />
+                  )}
                 </button>
               </div>
             </div>

--- a/client/src/components/modals/courses/CreateCourseModal.js
+++ b/client/src/components/modals/courses/CreateCourseModal.js
@@ -1,325 +1,401 @@
-import React, { useState, useEffect } from 'react';
-import axiosInstance from "../../../utils/axios";
+import React, { useState, useEffect, useRef } from 'react';
+import axiosInstance from '../../../utils/axios';
 import DiscardChangesModal from '../common/DiscardChangesModal';
 import ModalTextField from '../../form/ModalTextField';
 import ModalSelectField from '../../form/ModalSelectField';
 
-function CreateCourseModal({ setCreateCourseModal, create_course_modal, fetchCourses, isLocked = false }) {
-    const [formData, setFormData] = useState({
+function CreateCourseModal({
+  setCreateCourseModal,
+  create_course_modal,
+  fetchCourses,
+  isLocked = false,
+}) {
+  const [formData, setFormData] = useState({
+    name: '',
+    maxNumber: 30,
+    visibility: 'hidden',
+    description: '',
+    price: '',
+    scheduleDays: [],
+    scheduleTime: '',
+  });
+
+  const [showDiscardModal, setShowDiscardModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [isDaysDropdownOpen, setIsDaysDropdownOpen] = useState(false);
+  const daysDropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        daysDropdownRef.current &&
+        !daysDropdownRef.current.contains(event.target)
+      ) {
+        setIsDaysDropdownOpen(false);
+      }
+    };
+
+    if (isDaysDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isDaysDropdownOpen]);
+
+  useEffect(() => {
+    if (!create_course_modal) {
+      setShowDiscardModal(false);
+      setFormData({
         name: '',
         maxNumber: 30,
         visibility: 'hidden',
         description: '',
         price: '',
-        scheduleDays: '',
+        scheduleDays: [],
         scheduleTime: '',
-        adviser: ''
+      });
+      setError('');
+    }
+  }, [create_course_modal]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: name === 'maxNumber' ? parseInt(value) || 0 : value,
+    }));
+    if (error) setError('');
+  };
+
+  // Helper function to sort days by week order
+  const sortDaysByWeekOrder = (days) => {
+    const weekOrder = ['M', 'T', 'W', 'TH', 'F', 'SAT', 'SUN'];
+    return [...days].sort(
+      (a, b) => weekOrder.indexOf(a) - weekOrder.indexOf(b)
+    );
+  };
+
+  // Handle day selection with auto-sorting
+  const handleDayToggle = (day) => {
+    setFormData((prev) => {
+      const currentDays = prev.scheduleDays || [];
+      const newDays = currentDays.includes(day)
+        ? currentDays.filter((d) => d !== day)
+        : [...currentDays, day];
+      return {
+        ...prev,
+        scheduleDays: sortDaysByWeekOrder(newDays),
+      };
     });
+    if (error) setError('');
+  };
 
-    const [showDiscardModal, setShowDiscardModal] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState('');
-    const [advisers, setAdvisers] = useState([]);
+  const validateForm = () => {
+    if (!formData.name.trim()) {
+      setError('Course name is required');
+      return false;
+    }
+    if (formData.maxNumber <= 0) {
+      setError('Number of students must be greater than 0');
+      return false;
+    }
+    if (!formData.price || parseFloat(formData.price) < 0) {
+      setError('Valid price is required');
+      return false;
+    }
+    return true;
+  };
 
-    const fetchAdvisers = async () => {
-        try {
-            const response = await axiosInstance.get('/users?role=teacher');
-            const teacherOptions = response.data.data.map(teacher => ({
-                value: teacher.id.toString(),
-                label: `${teacher.firstName} ${teacher.middleName ? teacher.middleName + ' ' : ''}${teacher.lastName}`
-            }));
-            setAdvisers(teacherOptions);
-        } catch (error) {
-            console.error('Failed to fetch advisers:', error);
-            // Don't set error as it's not critical for form submission
-            setAdvisers([{ value: 'error', label: 'Failed to load advisers' }]);
-        }
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
 
-    useEffect(() => {
-        fetchAdvisers();
-    }, []);
+    if (!validateForm()) return;
 
-    useEffect(() => {
-        if (!create_course_modal) {
-            setShowDiscardModal(false);
-            setFormData({
-                name: '',
-                maxNumber: 30,
-                visibility: 'hidden',
-                description: '',
-                price: '',
-                scheduleDays: '',
-                scheduleTime: '',
-                adviser: ''
-            });
-            setError('');
-        }
-    }, [create_course_modal]);
+    try {
+      setLoading(true);
+      setError('');
 
-    const handleInputChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({
-            ...prev,
-            [name]: name === 'maxNumber' ? parseInt(value) || 0 : value
-        }));
-        if (error) setError('');
-    };
+      const scheduleDaysString = formData.scheduleDays.join('');
 
-    const validateForm = () => {
-        if (!formData.name.trim()) {
-            setError('Course name is required');
-            return false;
-        }
-        if (formData.maxNumber <= 0) {
-            setError('Number of students must be greater than 0');
-            return false;
-        }
-        if (!formData.price || parseFloat(formData.price) < 0) {
-            setError('Valid price is required');
-            return false;
-        }
-        return true;
-    };
+      const payload = {
+        name: formData.name.trim(),
+        maxNumber: parseInt(formData.maxNumber),
+        visibility: formData.visibility,
+        description: formData.description.trim(),
+        price: parseFloat(formData.price),
+        schedule:
+          scheduleDaysString && formData.scheduleTime.trim()
+            ? {
+                days: scheduleDaysString,
+                time: formData.scheduleTime.trim(),
+              }
+            : null,
+      };
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        
-        if (!validateForm()) return;
+      const response = await axiosInstance.post('/courses/create', payload);
+      console.log('Course created:', response.data);
 
-        try {
-            setLoading(true);
-            setError('');
+      await fetchCourses();
+      setCreateCourseModal(false);
+    } catch (error) {
+      console.error(
+        'Failed to create course: ',
+        error.response?.data || error.message
+      );
+      setError(
+        error.response?.data?.message ||
+          'Failed to create course. Please try again.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
 
-            const payload = {
-                name: formData.name.trim(),
-                maxNumber: parseInt(formData.maxNumber),
-                visibility: formData.visibility,
-                description: formData.description.trim(),
-                price: parseFloat(formData.price),
-                schedule: (formData.scheduleDays.trim() && formData.scheduleTime.trim()) ? {
-                    days: formData.scheduleDays.trim(),
-                    time: formData.scheduleTime.trim()
-                } : null,
-                adviserId: formData.adviser.trim() || null
-            };
+  const hasChanges = () => {
+    return Object.entries(formData).some(([key, value]) => {
+      if (key === 'maxNumber') return value !== 30;
+      if (key === 'visibility') return value !== 'hidden';
+      if (key === 'scheduleDays') return value.length > 0;
+      return value.toString().trim() !== '';
+    });
+  };
 
-            const response = await axiosInstance.post('/courses/create', payload);
-            console.log('Course created:', response.data);
-            
-            await fetchCourses();
-            setCreateCourseModal(false);
-            
-        } catch (error) {
-            console.error('Failed to create course: ', error.response?.data || error.message);
-            setError(error.response?.data?.message || 'Failed to create course. Please try again.');
-        } finally {
-            setLoading(false);
-        }
-    };
+  const handleClose = () => {
+    if (hasChanges()) {
+      setShowDiscardModal(true);
+    } else {
+      setCreateCourseModal(false);
+    }
+  };
 
-    const hasChanges = () => {
-        return Object.entries(formData).some(([key, value]) => {
-            if (key === 'maxNumber') return value !== 30;
-            if (key === 'visibility') return value !== 'hidden';
-            return value.toString().trim() !== "";
-        });
-    };
+  const handleDiscardChanges = () => {
+    setShowDiscardModal(false);
+    setCreateCourseModal(false);
+  };
 
-    const handleClose = () => {
-        if (hasChanges()) {
-            setShowDiscardModal(true);
-        } else {
-            setCreateCourseModal(false);
-        }
-    };
+  const handleCancelDiscard = () => {
+    setShowDiscardModal(false);
+  };
 
-    const handleDiscardChanges = () => {
-        setShowDiscardModal(false);
-        setCreateCourseModal(false);
-    };
+  if (!create_course_modal) return null;
 
-    const handleCancelDiscard = () => {
-        setShowDiscardModal(false);
-    };
+  const visibilityOptions = [
+    { value: 'visible', label: 'Visible' },
+    { value: 'hidden', label: 'Hidden' },
+  ];
 
-    if (!create_course_modal) return null;
+  return (
+    <>
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-visible">
+          {/* Header */}
+          <div className="flex items-start justify-between mb-6">
+            <h2 className="text-2xl font-bold">Course Creation</h2>
+            <button
+              className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
+              onClick={handleClose}
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
 
-    const visibilityOptions = [
-        { value: 'visible', label: 'Visible' },
-        { value: 'hidden', label: 'Hidden' }
-    ];
+          {/* Error Display */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
 
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Course Name */}
+            <ModalTextField
+              label="Course Name"
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
+              placeholder="Enter course name"
+              required
+            />
 
+            {/* Row 1: Students, Visibility, Price */}
+            <div className="flex flex-row justify-center items-center gap-4">
+              <ModalTextField
+                label="# of Students"
+                name="maxNumber"
+                type="number"
+                value={formData.maxNumber}
+                onChange={handleInputChange}
+                min="1"
+                required
+                className="w-1/3"
+              />
 
-    return (
-        <>
-            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
-                    {/* Header */}
-                    <div className="flex items-start justify-between mb-6">
-                        <h2 className="text-2xl font-bold">Course Creation</h2>
-                        <button
-                            className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
-                            onClick={handleClose}
-                        >
-                            <svg
-                                className="h-5 w-5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    d="M6 18L18 6M6 6l12 12"
-                                />
-                            </svg>
-                        </button>
-                    </div>
+              {!isLocked && (
+                <ModalSelectField
+                  label="Visibility"
+                  name="visibility"
+                  value={formData.visibility}
+                  onChange={handleInputChange}
+                  options={visibilityOptions}
+                  className="w-1/3"
+                />
+              )}
 
-                    {/* Error Display */}
-                    {error && (
-                        <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
-                            {error}
-                        </div>
-                    )}
-
-                    {/* Form */}
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        {/* Course Name */}
-                        <ModalTextField
-                            label="Course Name"
-                            name="name"
-                            value={formData.name}
-                            onChange={handleInputChange}
-                            placeholder="Enter course name"
-                            required
-                        />
-
-                        {/* Row 1: Students, Visibility, Price */}
-                        <div className="flex flex-row justify-center items-center gap-4">
-                            <ModalTextField
-                                label="# of Students"
-                                name="maxNumber"
-                                type="number"
-                                value={formData.maxNumber}
-                                onChange={handleInputChange}
-                                min="1"
-                                required
-                                className="w-1/3"
-                            />
-
-                            {!isLocked && (
-                                <ModalSelectField
-                                    label="Visibility"
-                                    name="visibility"
-                                    value={formData.visibility}
-                                    onChange={handleInputChange}
-                                    options={visibilityOptions}
-                                    className="w-1/3"
-                                />
-                            )}
-
-                            <ModalTextField
-                                label="Price"
-                                name="price"
-                                type="number"
-                                step="0.01"
-                                value={formData.price}
-                                onChange={handleInputChange}
-                                placeholder="0.00"
-                                min="0"
-                                required
-                                className={isLocked ? "w-1/2" : "w-1/3"}
-                            >
-                                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 font-medium">
-                                    ₱
-                                </span>
-                            </ModalTextField>
-                        </div>
-
-                        {/* Description */}
-                        <ModalTextField
-                            label="Description"
-                            name="description"
-                            value={formData.description}
-                            onChange={handleInputChange}
-                            placeholder="Enter course description"
-                        />
-
-                        {/* Schedule Fields */}
-                        <div className="flex flex-row justify-center items-center gap-4">
-                            <ModalSelectField
-                                label="Schedule Days"
-                                name="scheduleDays"
-                                value={formData.scheduleDays}
-                                onChange={handleInputChange}
-                                options={[
-                                    { value: '', label: 'Select days' },
-                                    { value: 'MWF', label: 'Monday, Wednesday, Friday' },
-                                    { value: 'TTH', label: 'Tuesday, Thursday' },
-                                    { value: 'MW', label: 'Monday, Wednesday' },
-                                    { value: 'TF', label: 'Tuesday, Friday' },
-                                    { value: 'WF', label: 'Wednesday, Friday' },
-                                    { value: 'SAT', label: 'Saturday' },
-                                    { value: 'SUN', label: 'Sunday' }
-                                ]}
-                                className="w-1/2"
-                            />
-                            
-                            <ModalTextField
-                                label="Schedule Time"
-                                name="scheduleTime"
-                                value={formData.scheduleTime}
-                                onChange={handleInputChange}
-                                placeholder="e.g. 6:30AM - 7:30AM"
-                                className="w-1/2"
-                            />
-                        </div>
-
-                        {/* Adviser Dropdown - New Field */}
-                        <ModalSelectField
-                            label="Adviser"
-                            name="adviser"
-                            value={formData.adviser}
-                            onChange={handleInputChange}
-                            options={[
-                                { value: '', label: 'Select an adviser' },
-                                ...advisers
-                            ]}
-                            className="w-full"
-                        />
-
-                        {/* Submit Button */}
-                        <div className="flex justify-center mt-6">
-                            <button
-                                type="submit"
-                                disabled={loading}
-                                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {loading ? (
-                                    <div className="flex items-center space-x-2">
-                                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                                        <span>Creating...</span>
-                                    </div>
-                                ) : (
-                                    'Submit'
-                                )}
-                            </button>
-                        </div>
-                    </form>
-                </div>
+              <ModalTextField
+                label="Price"
+                name="price"
+                type="number"
+                step="0.01"
+                value={formData.price}
+                onChange={handleInputChange}
+                placeholder="0.00"
+                min="0"
+                required
+                className={isLocked ? 'w-1/2' : 'w-1/3'}
+              >
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 font-medium">
+                  ₱
+                </span>
+              </ModalTextField>
             </div>
 
-            <DiscardChangesModal
-                show={showDiscardModal}
-                onConfirm={handleDiscardChanges}
-                onCancel={handleCancelDiscard}
+            {/* Description */}
+            <ModalTextField
+              label="Description"
+              name="description"
+              value={formData.description}
+              onChange={handleInputChange}
+              placeholder="Enter course description"
             />
-        </>
-    );
+
+            {/* Schedule Fields */}
+            <div className="flex flex-row justify-center items-center gap-4">
+              {/* Schedule Days Multi-Select Dropdown */}
+              <div className="w-1/2 relative" ref={daysDropdownRef}>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Schedule Days
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setIsDaysDropdownOpen(!isDaysDropdownOpen)}
+                  className="w-full bg-white border border-gray-300 rounded-md px-3 py-2 text-left flex justify-between items-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-dark-red-2 focus:border-dark-red-2"
+                >
+                  <span
+                    className={
+                      formData.scheduleDays.length > 0
+                        ? 'text-gray-900'
+                        : 'text-gray-400'
+                    }
+                  >
+                    {formData.scheduleDays.length > 0
+                      ? formData.scheduleDays.join('')
+                      : 'Select days'}
+                  </span>
+                  <svg
+                    className={`w-5 h-5 text-gray-400 transition-transform ${
+                      isDaysDropdownOpen ? 'transform rotate-180' : ''
+                    }`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Floating Dropdown */}
+                {isDaysDropdownOpen && (
+                  <div className="absolute z-[80] w-full bottom-full mb-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+                    <div className="p-2 space-y-1">
+                      {[
+                        { value: 'M', label: 'Monday' },
+                        { value: 'T', label: 'Tuesday' },
+                        { value: 'W', label: 'Wednesday' },
+                        { value: 'TH', label: 'Thursday' },
+                        { value: 'F', label: 'Friday' },
+                        { value: 'SAT', label: 'Saturday' },
+                        { value: 'SUN', label: 'Sunday' },
+                      ].map((day) => (
+                        <label
+                          key={day.value}
+                          className="flex items-center space-x-2 cursor-pointer hover:bg-gray-50 p-2 rounded"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={formData.scheduleDays.includes(day.value)}
+                            onChange={() => handleDayToggle(day.value)}
+                            className="w-4 h-4 text-dark-red-2 border-gray-300 rounded focus:ring-dark-red-2"
+                          />
+                          <span className="text-sm text-gray-700">
+                            {day.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <ModalTextField
+                label="Schedule Time"
+                name="scheduleTime"
+                value={formData.scheduleTime}
+                onChange={handleInputChange}
+                placeholder="e.g. 6:30AM - 7:30AM"
+                className="w-1/2"
+              />
+            </div>
+
+            {/* Submit Button */}
+            <div className="flex justify-center mt-6">
+              <button
+                type="submit"
+                disabled={loading}
+                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? (
+                  <div className="flex items-center space-x-2">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <span>Creating...</span>
+                  </div>
+                ) : (
+                  'Submit'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <DiscardChangesModal
+        show={showDiscardModal}
+        onConfirm={handleDiscardChanges}
+        onCancel={handleCancelDiscard}
+      />
+    </>
+  );
 }
 
 export default CreateCourseModal;

--- a/client/src/components/modals/courses/EditCourseModal.js
+++ b/client/src/components/modals/courses/EditCourseModal.js
@@ -1,338 +1,438 @@
-import React, { useEffect, useState } from 'react';
-import axiosInstance from "../../../utils/axios";
+import React, { useEffect, useState, useRef } from 'react';
+import axiosInstance from '../../../utils/axios';
 import DiscardChangesModal from '../common/DiscardChangesModal';
 import ModalTextField from '../../form/ModalTextField';
 import ModalSelectField from '../../form/ModalSelectField';
 
-function EditCourseModal({ edit_course_modal, setEditCourseModal, selectedCourse, fetchCourses, isLocked = false }) {
-    const [formData, setFormData] = useState({
+function EditCourseModal({
+  edit_course_modal,
+  setEditCourseModal,
+  selectedCourse,
+  fetchCourses,
+  isLocked = false,
+}) {
+  const [formData, setFormData] = useState({
+    name: '',
+    maxNumber: 30,
+    visibility: 'hidden',
+    description: '',
+    price: '',
+    scheduleDays: [],
+    scheduleTime: '',
+  });
+
+  const [showDiscardModal, setShowDiscardModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [originalData, setOriginalData] = useState({});
+  const [isDaysDropdownOpen, setIsDaysDropdownOpen] = useState(false);
+  const daysDropdownRef = useRef(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        daysDropdownRef.current &&
+        !daysDropdownRef.current.contains(event.target)
+      ) {
+        setIsDaysDropdownOpen(false);
+      }
+    };
+
+    if (isDaysDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isDaysDropdownOpen]);
+
+  // Helper function to convert days string to array
+  const parseDaysString = (daysString) => {
+    if (!daysString) return [];
+    const weekOrder = ['M', 'T', 'W', 'TH', 'F', 'SAT', 'SUN'];
+    const days = [];
+    let remaining = daysString;
+
+    // Parse in order to handle multi-character days like TH, SAT, SUN
+    for (const day of weekOrder) {
+      if (remaining.includes(day)) {
+        days.push(day);
+        remaining = remaining.replace(day, '');
+      }
+    }
+    return days;
+  };
+
+  useEffect(() => {
+    if (selectedCourse && edit_course_modal) {
+      const courseData = {
+        name: selectedCourse.name || '',
+        maxNumber: selectedCourse.maxNumber || 30,
+        visibility: selectedCourse.visibility || 'hidden',
+        description: selectedCourse.description || '',
+        price: selectedCourse.price || '',
+        scheduleDays: parseDaysString(selectedCourse.schedule?.days || ''),
+        scheduleTime: selectedCourse.schedule?.time || '',
+        adviser: selectedCourse.adviserId || '',
+      };
+      setFormData(courseData);
+      setOriginalData(courseData);
+    }
+  }, [selectedCourse, edit_course_modal]);
+
+  useEffect(() => {
+    if (!edit_course_modal) {
+      setShowDiscardModal(false);
+      setFormData({
         name: '',
         maxNumber: 30,
         visibility: 'hidden',
         description: '',
         price: '',
-        scheduleDays: '',
+        scheduleDays: [],
         scheduleTime: '',
-        adviser: ''
+        adviser: '',
+      });
+      setOriginalData({});
+      setError('');
+    }
+  }, [edit_course_modal]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: name === 'maxNumber' ? parseInt(value) || 0 : value,
+    }));
+    if (error) setError('');
+  };
+
+  // Helper function to sort days by week order
+  const sortDaysByWeekOrder = (days) => {
+    const weekOrder = ['M', 'T', 'W', 'TH', 'F', 'SAT', 'SUN'];
+    return [...days].sort(
+      (a, b) => weekOrder.indexOf(a) - weekOrder.indexOf(b)
+    );
+  };
+
+  // Handle day selection with auto-sorting
+  const handleDayToggle = (day) => {
+    setFormData((prev) => {
+      const currentDays = prev.scheduleDays || [];
+      const newDays = currentDays.includes(day)
+        ? currentDays.filter((d) => d !== day)
+        : [...currentDays, day];
+      return {
+        ...prev,
+        scheduleDays: sortDaysByWeekOrder(newDays),
+      };
     });
+    if (error) setError('');
+  };
 
-    const [showDiscardModal, setShowDiscardModal] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState('');
-    const [originalData, setOriginalData] = useState({});
-    const [advisers, setAdvisers] = useState([]);
+  const validateForm = () => {
+    if (!formData.name.trim()) {
+      setError('Course name is required');
+      return false;
+    }
+    if (formData.maxNumber <= 0) {
+      setError('Number of students must be greater than 0');
+      return false;
+    }
+    if (!formData.price || parseFloat(formData.price) < 0) {
+      setError('Valid price is required');
+      return false;
+    }
+    return true;
+  };
 
-    // Fetch advisers (teachers) when component mounts
-    const fetchAdvisers = async () => {
-        try {
-            const response = await axiosInstance.get('/users?role=teacher');
-            const teacherOptions = response.data.data.map(teacher => ({
-                value: teacher.id.toString(),
-                label: `${teacher.firstName} ${teacher.middleName ? teacher.middleName + ' ' : ''}${teacher.lastName}`
-            }));
-            setAdvisers(teacherOptions);
-        } catch (error) {
-            console.error('Failed to fetch advisers:', error);
-            setAdvisers([{ value: 'error', label: 'Failed to load advisers' }]);
-        }
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
 
-    useEffect(() => {
-        fetchAdvisers();
-    }, []);
+    if (!validateForm()) return;
 
-    useEffect(() => {
-        if (selectedCourse && edit_course_modal) {
-            const courseData = {
-                name: selectedCourse.name || '',
-                maxNumber: selectedCourse.maxNumber || 30,
-                visibility: selectedCourse.visibility || 'hidden',
-                description: selectedCourse.description || '',
-                price: selectedCourse.price || '',
-                scheduleDays: selectedCourse.schedule?.days || '',
-                scheduleTime: selectedCourse.schedule?.time || '',
-                adviser: selectedCourse.adviserId || ''
-            };
-            setFormData(courseData);
-            setOriginalData(courseData);
-        }
-    }, [selectedCourse, edit_course_modal]);
+    try {
+      setLoading(true);
+      setError('');
 
-    useEffect(() => {
-        if (!edit_course_modal) {
-            setShowDiscardModal(false);
-            setFormData({
-                name: '',
-                maxNumber: 30,
-                visibility: 'hidden',
-                description: '',
-                price: '',
-                scheduleDays: '',
-                scheduleTime: '',
-                adviser: ''
-            });
-            setOriginalData({});
-            setError('');
-        }
-    }, [edit_course_modal]);
+      const scheduleDaysString = formData.scheduleDays.join('');
 
-    const handleInputChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({
-            ...prev,
-            [name]: name === 'maxNumber' ? parseInt(value) || 0 : value
-        }));
-        if (error) setError('');
-    };
+      const payload = {
+        name: formData.name.trim(),
+        maxNumber: parseInt(formData.maxNumber),
+        visibility: formData.visibility,
+        description: formData.description.trim(),
+        price: parseFloat(formData.price),
+        schedule:
+          scheduleDaysString && formData.scheduleTime.trim()
+            ? {
+                days: scheduleDaysString,
+                time: formData.scheduleTime.trim(),
+              }
+            : null,
+        // adviserId: formData.adviser.trim() || null
+      };
 
-    const validateForm = () => {
-        if (!formData.name.trim()) {
-            setError('Course name is required');
-            return false;
-        }
-        if (formData.maxNumber <= 0) {
-            setError('Number of students must be greater than 0');
-            return false;
-        }
-        if (!formData.price || parseFloat(formData.price) < 0) {
-            setError('Valid price is required');
-            return false;
-        }
-        return true;
-    };
+      const response = await axiosInstance.put(
+        `/courses/${selectedCourse.id}`,
+        payload
+      );
+      console.log('Course updated:', response.data);
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
+      await fetchCourses();
+      setEditCourseModal(false);
+    } catch (error) {
+      console.error(
+        'Failed to update course: ',
+        error.response?.data || error.message
+      );
+      setError(
+        error.response?.data?.message ||
+          'Failed to update course. Please try again.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
 
-        if (!validateForm()) return;
+  const hasChanges = () => {
+    return Object.entries(formData).some(([key, value]) => {
+      return JSON.stringify(value) !== JSON.stringify(originalData[key]);
+    });
+  };
 
-        try {
-            setLoading(true);
-            setError('');
+  const handleClose = () => {
+    if (hasChanges()) {
+      setShowDiscardModal(true);
+    } else {
+      setEditCourseModal(false);
+    }
+  };
 
-            const payload = {
-                name: formData.name.trim(),
-                maxNumber: parseInt(formData.maxNumber),
-                visibility: formData.visibility,
-                description: formData.description.trim(),
-                price: parseFloat(formData.price),
-                schedule: (formData.scheduleDays.trim() && formData.scheduleTime.trim()) ? {
-                    days: formData.scheduleDays.trim(),
-                    time: formData.scheduleTime.trim()
-                } : null,
-                adviserId: formData.adviser.trim() || null
-            };
+  const handleDiscardChanges = () => {
+    setShowDiscardModal(false);
+    setEditCourseModal(false);
+  };
 
-            const response = await axiosInstance.put(`/courses/${selectedCourse.id}`, payload);
-            console.log('Course updated:', response.data);
+  const handleCancelDiscard = () => {
+    setShowDiscardModal(false);
+  };
 
-            await fetchCourses();
-            setEditCourseModal(false);
+  if (!edit_course_modal) return null;
 
-        } catch (error) {
-            console.error('Failed to update course: ', error.response?.data || error.message);
-            setError(error.response?.data?.message || 'Failed to update course. Please try again.');
-        } finally {
-            setLoading(false);
-        }
-    };
+  const visibilityOptions = [
+    { value: 'visible', label: 'Visible' },
+    { value: 'hidden', label: 'Hidden' },
+  ];
 
-    const hasChanges = () => {
-        return Object.entries(formData).some(([key, value]) => {
-            return JSON.stringify(value) !== JSON.stringify(originalData[key]);
-        });
-    };
+  return (
+    <>
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
+          <div className="flex items-start justify-between mb-6">
+            <h2 className="text-2xl font-bold">Edit Course</h2>
+            <button
+              className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
+              onClick={handleClose}
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
 
-    const handleClose = () => {
-        if (hasChanges()) {
-            setShowDiscardModal(true);
-        } else {
-            setEditCourseModal(false);
-        }
-    };
+          {/* Error Display */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
 
-    const handleDiscardChanges = () => {
-        setShowDiscardModal(false);
-        setEditCourseModal(false);
-    };
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <ModalTextField
+              label="Course Name"
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
+              placeholder="Enter course name"
+              required
+            />
 
-    const handleCancelDiscard = () => {
-        setShowDiscardModal(false);
-    };
+            {/* Row 1: Students, Visibility, Price */}
+            <div className="flex flex-row justify-center items-center gap-4">
+              <ModalTextField
+                label="# of Students"
+                name="maxNumber"
+                type="number"
+                value={formData.maxNumber}
+                onChange={handleInputChange}
+                min="1"
+                required
+                className="w-1/3"
+              />
 
-    if (!edit_course_modal) return null;
+              {!isLocked && (
+                <ModalSelectField
+                  label="Visibility"
+                  name="visibility"
+                  value={formData.visibility}
+                  onChange={handleInputChange}
+                  options={visibilityOptions}
+                  className="w-1/3"
+                />
+              )}
 
-    const visibilityOptions = [
-        { value: 'visible', label: 'Visible' },
-        { value: 'hidden', label: 'Hidden' }
-    ];
-
-    return (
-        <>
-            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
-                    <div className="flex items-start justify-between mb-6">
-                        <h2 className="text-2xl font-bold">Edit Course</h2>
-                        <button
-                            className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
-                            onClick={handleClose}
-                        >
-                            <svg
-                                className="h-5 w-5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    d="M6 18L18 6M6 6l12 12"
-                                />
-                            </svg>
-                        </button>
-                    </div>
-
-                    {/* Error Display */}
-                    {error && (
-                        <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
-                            {error}
-                        </div>
-                    )}
-
-                    {/* Form */}
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        <ModalTextField
-                            label="Course Name"
-                            name="name"
-                            value={formData.name}
-                            onChange={handleInputChange}
-                            placeholder="Enter course name"
-                            required
-                        />
-
-                        {/* Row 1: Students, Visibility, Price */}
-                        <div className="flex flex-row justify-center items-center gap-4">
-                            <ModalTextField
-                                label="# of Students"
-                                name="maxNumber"
-                                type="number"
-                                value={formData.maxNumber}
-                                onChange={handleInputChange}
-                                min="1"
-                                required
-                                className="w-1/3"
-                            />
-
-                            {!isLocked && (
-                                <ModalSelectField
-                                    label="Visibility"
-                                    name="visibility"
-                                    value={formData.visibility}
-                                    onChange={handleInputChange}
-                                    options={visibilityOptions}
-                                    className="w-1/3"
-                                />
-                            )}
-
-                            <ModalTextField
-                                label="Price"
-                                name="price"
-                                type="number"
-                                step="0.01"
-                                value={formData.price}
-                                onChange={handleInputChange}
-                                placeholder="0.00"
-                                min="0"
-                                required
-                                className={isLocked ? "w-1/2" : "w-1/3"}
-                            >
-                                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 font-medium">
-                                    ₱
-                                </span>
-                            </ModalTextField>
-                        </div>
-
-                        {/* Description */}
-                        <ModalTextField
-                            label="Description"
-                            name="description"
-                            value={formData.description}
-                            onChange={handleInputChange}
-                            placeholder="Enter course description"
-                        />
-
-                        {/* Schedule Fields */}
-                        <div className="flex flex-row justify-center items-center gap-4">
-                            <ModalSelectField
-                                label="Schedule Days"
-                                name="scheduleDays"
-                                value={formData.scheduleDays}
-                                onChange={handleInputChange}
-                                options={[
-                                    { value: '', label: 'Select days' },
-                                    { value: 'MWF', label: 'Monday, Wednesday, Friday' },
-                                    { value: 'TTH', label: 'Tuesday, Thursday' },
-                                    { value: 'MW', label: 'Monday, Wednesday' },
-                                    { value: 'TF', label: 'Tuesday, Friday' },
-                                    { value: 'WF', label: 'Wednesday, Friday' },
-                                    { value: 'SAT', label: 'Saturday' },
-                                    { value: 'SUN', label: 'Sunday' }
-                                ]}
-                                className="w-1/2"
-                            />
-
-                            <ModalTextField
-                                label="Schedule Time"
-                                name="scheduleTime"
-                                value={formData.scheduleTime}
-                                onChange={handleInputChange}
-                                placeholder="e.g. 6:30AM - 7:30AM"
-                                className="w-1/2"
-                            />
-                        </div>
-
-                        {/* Adviser Dropdown */}
-                        <ModalSelectField
-                            label="Adviser"
-                            name="adviser"
-                            value={formData.adviser}
-                            onChange={handleInputChange}
-                            options={[
-                                { value: '', label: 'Select an adviser' },
-                                ...advisers
-                            ]}
-                            className="w-full"
-                        />
-
-                        {/* Submit Button */}
-                        <div className="flex justify-center mt-6">
-                            <button
-                                type="submit"
-                                disabled={loading}
-                                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {loading ? (
-                                    <div className="flex items-center space-x-2">
-                                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                                        <span>Updating...</span>
-                                    </div>
-                                ) : (
-                                    'Submit'
-                                )}
-                            </button>
-                        </div>
-                    </form>
-                </div>
+              <ModalTextField
+                label="Price"
+                name="price"
+                type="number"
+                step="0.01"
+                value={formData.price}
+                onChange={handleInputChange}
+                placeholder="0.00"
+                min="0"
+                required
+                className={isLocked ? 'w-1/2' : 'w-1/3'}
+              >
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 font-medium">
+                  ₱
+                </span>
+              </ModalTextField>
             </div>
 
-            <DiscardChangesModal
-                show={showDiscardModal}
-                onConfirm={handleDiscardChanges}
-                onCancel={handleCancelDiscard}
+            {/* Description */}
+            <ModalTextField
+              label="Description"
+              name="description"
+              value={formData.description}
+              onChange={handleInputChange}
+              placeholder="Enter course description"
             />
-        </>
-    );
+
+            {/* Schedule Fields */}
+            <div className="flex flex-row justify-center items-center gap-4">
+              {/* Schedule Days Multi-Select Dropdown */}
+              <div className="w-1/2 relative" ref={daysDropdownRef}>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Schedule Days
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setIsDaysDropdownOpen(!isDaysDropdownOpen)}
+                  className="w-full bg-white border border-gray-300 rounded-md px-3 py-2 text-left flex justify-between items-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-dark-red-2 focus:border-dark-red-2"
+                >
+                  <span
+                    className={
+                      formData.scheduleDays.length > 0
+                        ? 'text-gray-900'
+                        : 'text-gray-400'
+                    }
+                  >
+                    {formData.scheduleDays.length > 0
+                      ? formData.scheduleDays.join('')
+                      : 'Select days'}
+                  </span>
+                  <svg
+                    className={`w-5 h-5 text-gray-400 transition-transform ${
+                      isDaysDropdownOpen ? 'transform rotate-180' : ''
+                    }`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Floating Dropdown */}
+                {isDaysDropdownOpen && (
+                  <div className="absolute z-[80] w-full bottom-full mb-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+                    <div className="p-2 space-y-1">
+                      {[
+                        { value: 'M', label: 'Monday' },
+                        { value: 'T', label: 'Tuesday' },
+                        { value: 'W', label: 'Wednesday' },
+                        { value: 'TH', label: 'Thursday' },
+                        { value: 'F', label: 'Friday' },
+                        { value: 'SAT', label: 'Saturday' },
+                        { value: 'SUN', label: 'Sunday' },
+                      ].map((day) => (
+                        <label
+                          key={day.value}
+                          className="flex items-center space-x-2 cursor-pointer hover:bg-gray-50 p-2 rounded"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={formData.scheduleDays.includes(day.value)}
+                            onChange={() => handleDayToggle(day.value)}
+                            className="w-4 h-4 text-dark-red-2 border-gray-300 rounded focus:ring-dark-red-2"
+                          />
+                          <span className="text-sm text-gray-700">
+                            {day.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <ModalTextField
+                label="Schedule Time"
+                name="scheduleTime"
+                value={formData.scheduleTime}
+                onChange={handleInputChange}
+                placeholder="e.g. 6:30AM - 7:30AM"
+                className="w-1/2"
+              />
+            </div>
+
+            {/* Submit Button */}
+            <div className="flex justify-center mt-6">
+              <button
+                type="submit"
+                disabled={loading}
+                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? (
+                  <div className="flex items-center space-x-2">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <span>Updating...</span>
+                  </div>
+                ) : (
+                  'Submit'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <DiscardChangesModal
+        show={showDiscardModal}
+        onConfirm={handleDiscardChanges}
+        onCancel={handleCancelDiscard}
+      />
+    </>
+  );
 }
 
 export default EditCourseModal;

--- a/client/src/components/modals/enrollment/AddAcademicPeriodModal.js
+++ b/client/src/components/modals/enrollment/AddAcademicPeriodModal.js
@@ -1,232 +1,244 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from "../../../utils/axios";
+import axiosInstance from '../../../utils/axios';
 import DiscardChangesModal from '../common/DiscardChangesModal';
 import ModalTextField from '../../form/ModalTextField';
 
-function AcademicPeriodModal({ setAddAcademicPeriodModal, addAcademicPeriodModal, fetchPeriods }) {
-    const [formData, setFormData] = useState({
+function AcademicPeriodModal({
+  setAddAcademicPeriodModal,
+  addAcademicPeriodModal,
+  fetchPeriods,
+}) {
+  const [formData, setFormData] = useState({
+    batchName: '',
+    periodName: '',
+    startAt: '',
+    endAt: '',
+  });
+
+  const [showDiscardModal, setShowDiscardModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!addAcademicPeriodModal) {
+      setShowDiscardModal(false);
+      setFormData({
         batchName: '',
         periodName: '',
         startAt: '',
-        endAt: ''
-    });
+        endAt: '',
+      });
+      setError('');
+    }
+  }, [addAcademicPeriodModal]);
 
-    const [showDiscardModal, setShowDiscardModal] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState('');
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    if (error) setError('');
+  };
 
-    useEffect(() => {
-        if (!addAcademicPeriodModal) {
-            setShowDiscardModal(false);
-            setFormData({
-                batchName: '',
-                periodName: '',
-                startAt: '',
-                endAt: ''
-            });
-            setError('');
-        }
-    }, [addAcademicPeriodModal]);
+  const validateForm = () => {
+    if (!formData.batchName.trim()) {
+      setError('Batch name is required');
+      return false;
+    }
+    if (!formData.periodName.trim()) {
+      setError('Period name is required');
+      return false;
+    }
+    if (!formData.startAt) {
+      setError('Start date is required');
+      return false;
+    }
+    if (!formData.endAt) {
+      setError('End date is required');
+      return false;
+    }
+    if (new Date(formData.startAt) >= new Date(formData.endAt)) {
+      setError('End date must be after start date');
+      return false;
+    }
+    return true;
+  };
 
-    const handleInputChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({
-            ...prev,
-            [name]: value
-        }));
-        if (error) setError('');
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
 
-    const validateForm = () => {
-        if (!formData.batchName.trim()) {
-            setError('Batch name is required');
-            return false;
-        }
-        if (!formData.periodName.trim()) {
-            setError('Period name is required');
-            return false;
-        }
-        if (!formData.startAt) {
-            setError('Start date is required');
-            return false;
-        }
-        if (!formData.endAt) {
-            setError('End date is required');
-            return false;
-        }
-        if (new Date(formData.startAt) >= new Date(formData.endAt)) {
-            setError('End date must be after start date');
-            return false;
-        }
-        return true;
-    };
+    if (!validateForm()) return;
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        
-        if (!validateForm()) return;
+    try {
+      setLoading(true);
+      setError('');
 
-        try {
-            setLoading(true);
-            setError('');
+      const startDateTime = new Date(formData.startAt);
+      startDateTime.setHours(0, 0, 0, 0);
 
-            const startDateTime = new Date(formData.startAt);
-            startDateTime.setHours(0, 0, 0, 0);
+      const endDateTime = new Date(formData.endAt);
+      endDateTime.setHours(23, 59, 59, 999);
 
-            const endDateTime = new Date(formData.endAt);
-            endDateTime.setHours(23, 59, 59, 999);
+      const payload = {
+        batchName: formData.batchName.trim(),
+        periodName: formData.periodName.trim(),
+        startAt: startDateTime.toISOString(),
+        endAt: endDateTime.toISOString(),
+      };
 
-            const payload = {
-                batchName: formData.batchName.trim(),
-                periodName: formData.periodName.trim(),
-                startAt: startDateTime.toISOString(),
-                endAt: endDateTime.toISOString(),
-            };
+      console.log('Payload for creating academic period:', payload);
+      const response = await axiosInstance.post(
+        '/academic-periods/create',
+        payload
+      );
+      console.log('Academic Period created:', response.data);
 
-            console.log('Payload for creating academic period:', payload);
-            const response = await axiosInstance.post('/academic-periods/create', payload);
-            console.log('Academic Period created:', response.data);
-            
-            await fetchPeriods();
-            setAddAcademicPeriodModal(false);
-            
-        } catch (error) {
-            console.error('Failed to create academic period: ', error.response?.data || error.message);
-            setError(error.response?.data?.message || 'Failed to create academic period. Please try again.');
-        } finally {
-            setLoading(false);
-        }
-    };
+      await fetchPeriods();
+      setAddAcademicPeriodModal(false);
+    } catch (error) {
+      console.error(
+        'Failed to create academic period: ',
+        error.response?.data || error.message
+      );
+      setError(
+        error.response?.data?.message ||
+          'Failed to create academic period. Please try again.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    const hasChanges = () => {
-        return Object.values(formData).some(value => value.trim() !== "");
-    };
+  const hasChanges = () => {
+    return Object.values(formData).some((value) => value.trim() !== '');
+  };
 
-    const handleClose = () => {
-        if (hasChanges()) {
-            setShowDiscardModal(true);
-        } else {
-            setAddAcademicPeriodModal(false);
-        }
-    };
+  const handleClose = () => {
+    if (hasChanges()) {
+      setShowDiscardModal(true);
+    } else {
+      setAddAcademicPeriodModal(false);
+    }
+  };
 
-    const handleDiscardChanges = () => {
-        setShowDiscardModal(false);
-        setAddAcademicPeriodModal(false);
-    };
+  const handleDiscardChanges = () => {
+    setShowDiscardModal(false);
+    setAddAcademicPeriodModal(false);
+  };
 
-    const handleCancelDiscard = () => {
-        setShowDiscardModal(false);
-    };
+  const handleCancelDiscard = () => {
+    setShowDiscardModal(false);
+  };
 
-    if (!addAcademicPeriodModal) return null;
+  if (!addAcademicPeriodModal) return null;
 
-    return (
-        <>
-            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
-                    <div className="flex items-start justify-between mb-6">
-                        <h2 className="text-2xl font-bold">Period Creation</h2>
-                        <button
-                            className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
-                            onClick={handleClose}
-                        >
-                            <svg
-                                className="h-5 w-5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    d="M6 18L18 6M6 6l12 12"
-                                />
-                            </svg>
-                        </button>
-                    </div>
+  return (
+    <>
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white-yellow-tone rounded-lg p-6 w-full max-w-2xl mx-4 relative max-h-[90vh] overflow-y-auto">
+          <div className="flex items-start justify-between mb-6">
+            <h2 className="text-2xl font-bold">Period Creation</h2>
+            <button
+              className="inline-flex bg-dark-red-2 rounded-lg px-4 py-1.5 text-white hover:bg-dark-red-5 ease-in duration-150"
+              onClick={handleClose}
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
 
-                    {/* Error Display */}
-                    {error && (
-                        <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
-                            {error}
-                        </div>
-                    )}
+          {/* Error Display */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
 
-                    {/* Form */}
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        {/* Batch Name */}
-                        <ModalTextField
-                            label="Batch Name"
-                            name="batchName"
-                            value={formData.batchName}
-                            onChange={handleInputChange}
-                            placeholder="Enter batch name"
-                            required
-                        />
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Batch Name */}
+            <ModalTextField
+              label="Batch Name"
+              name="batchName"
+              value={formData.batchName}
+              onChange={handleInputChange}
+              placeholder="Enter batch name"
+              required
+            />
 
-                        {/* Period Name */}
-                        <ModalTextField
-                            label="Period Name"
-                            name="periodName"
-                            value={formData.periodName}
-                            onChange={handleInputChange}
-                            placeholder="Enter period name"
-                            required
-                        />
+            {/* Period Name */}
+            <ModalTextField
+              label="Period Name"
+              name="periodName"
+              value={formData.periodName}
+              onChange={handleInputChange}
+              placeholder="Enter period name"
+              required
+            />
 
-                        {/* Date Range */}
-                        <div className="flex flex-row justify-center items-center gap-4">
-                            <ModalTextField
-                                label="Start Date"
-                                name="startAt"
-                                type="date"
-                                value={formData.startAt}
-                                onChange={handleInputChange}
-                                required
-                                className="w-1/2"
-                            />
+            {/* Date Range */}
+            <div className="flex flex-row justify-center items-center gap-4">
+              <ModalTextField
+                label="Start Date"
+                name="startAt"
+                type="date"
+                value={formData.startAt}
+                onChange={handleInputChange}
+                required
+                className="w-1/2"
+              />
 
-                            <ModalTextField
-                                label="End Date"
-                                name="endAt"
-                                type="date"
-                                value={formData.endAt}
-                                onChange={handleInputChange}
-                                required
-                                className="w-1/2"
-                            />
-                        </div>
-
-                        {/* Submit Button */}
-                        <div className="flex justify-center mt-6">
-                            <button
-                                type="submit"
-                                disabled={loading}
-                                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {loading ? (
-                                    <div className="flex items-center space-x-2">
-                                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                                        <span>Creating...</span>
-                                    </div>
-                                ) : (
-                                    'Submit'
-                                )}
-                            </button>
-                        </div>
-                    </form>
-                </div>
+              <ModalTextField
+                label="End Date"
+                name="endAt"
+                type="date"
+                value={formData.endAt}
+                onChange={handleInputChange}
+                required
+                className="w-1/2"
+              />
             </div>
 
-            <DiscardChangesModal
-                show={showDiscardModal}
-                onConfirm={handleDiscardChanges}
-                onCancel={handleCancelDiscard}
-            />
-        </>
-    );
+            {/* Submit Button */}
+            <div className="flex justify-center mt-6">
+              <button
+                type="submit"
+                disabled={loading}
+                className="bg-dark-red-2 hover:bg-dark-red-5 text-white px-8 py-2 rounded font-semibold transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? (
+                  <div className="flex items-center space-x-2">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <span>Creating...</span>
+                  </div>
+                ) : (
+                  'Submit'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <DiscardChangesModal
+        show={showDiscardModal}
+        onConfirm={handleDiscardChanges}
+        onCancel={handleCancelDiscard}
+      />
+    </>
+  );
 }
 
 export default AcademicPeriodModal;

--- a/client/src/components/modals/schedule/CreateEditScheduleModal.js
+++ b/client/src/components/modals/schedule/CreateEditScheduleModal.js
@@ -1,0 +1,683 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  MdClose,
+  MdLocationOn,
+  MdAccessTime,
+  MdPerson,
+  MdRepeat,
+  MdCalendarToday,
+} from 'react-icons/md';
+import { FaAlignLeft } from 'react-icons/fa';
+import TeacherSelect from '../../inputs/TeacherSelect';
+import CourseSelect from '../../inputs/CourseSelect';
+import AcademicPeriodSelect from '../../inputs/AcademicPeriodSelect';
+import Swal from 'sweetalert2';
+
+/**
+ * Create/Edit Schedule Modal
+ * Form for creating or editing recurring schedule events
+ */
+function CreateEditScheduleModal({
+  isOpen,
+  onClose,
+  event,
+  selectedDate,
+  onSave,
+  onDelete,
+  teachers,
+  isLoadingTeachers,
+  courses,
+  isLoadingCourses,
+  academicPeriods,
+  isLoadingAcademicPeriods,
+}) {
+  const [formData, setFormData] = useState({
+    courseId: '',
+    courseName: '',
+    academicPeriodId: '',
+    academicPeriodName: '',
+    location: '',
+    time_start: '',
+    time_end: '',
+    days: '',
+    periodStart: '',
+    periodEnd: '',
+    teacherId: '',
+    teacherName: '',
+    notes: '',
+    color: '#FFCF00',
+  });
+
+  const colorOptions = [
+    '#4A90E2', // Blue
+    '#F5A623', // Orange
+    '#FFCF00', // Yellow
+    '#BD10E0', // Purple
+    '#50E3C2', // Teal
+    '#7ED321', // Green
+    '#D0021B', // Red
+    '#4A4A4A', // Gray
+    '#9013FE', // Violet
+  ];
+
+  useEffect(() => {
+    if (event) {
+      // Editing existing event
+      setFormData({
+        courseId: event.courseId || '',
+        courseName: event.courseName || event.title || '',
+        academicPeriodId: event.academicPeriodId || '',
+        academicPeriodName: event.academicPeriodName || '',
+        location: event.location || '',
+        time_start: event.time_start || '',
+        time_end: event.time_end || '',
+        days: event.days || '',
+        periodStart: event.periodStart || '',
+        periodEnd: event.periodEnd || '',
+        teacherId: event.teacherId || '',
+        teacherName: event.teacherName || '',
+        notes: event.notes || '',
+        color: event.color || '#FFCF00',
+      });
+    } else if (selectedDate) {
+      // Creating new event with default time from selectedDate if available
+      setFormData((prev) => ({
+        ...prev,
+        periodStart: selectedDate.toISOString().split('T')[0],
+      }));
+    }
+  }, [event, selectedDate]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleColorSelect = (color) => {
+    setFormData((prev) => ({ ...prev, color }));
+  };
+
+  const handleTeacherSelect = (teacher) => {
+    setFormData((prev) => ({
+      ...prev,
+      teacherId: teacher.id,
+      teacherName: `${teacher.firstName} ${teacher.lastName}`,
+    }));
+  };
+
+  const handleCourseSelect = (course) => {
+    setFormData((prev) => ({
+      ...prev,
+      courseId: course.id,
+      courseName: course.name,
+    }));
+  };
+
+  const handleAcademicPeriodSelect = (period) => {
+    // Format dates to YYYY-MM-DD for date input
+    const formatDate = (dateString) => {
+      const date = new Date(dateString);
+      return date.toISOString().split('T')[0];
+    };
+
+    setFormData((prev) => ({
+      ...prev,
+      academicPeriodId: period.id,
+      academicPeriodName: `${period.periodName}${
+        period.batchName ? ` - ${period.batchName}` : ''
+      }`,
+      // Automatically set schedule dates to match academic period dates
+      periodStart: formatDate(period.startAt),
+      periodEnd: formatDate(period.endAt),
+    }));
+  };
+
+  const handleDayToggle = (day) => {
+    const daysArray = formData.days
+      ? formData.days.split(',').map((d) => d.trim())
+      : [];
+    const dayIndex = daysArray.indexOf(day);
+
+    if (dayIndex > -1) {
+      // Remove day
+      daysArray.splice(dayIndex, 1);
+    } else {
+      // Add day
+      daysArray.push(day);
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      days: daysArray.join(','),
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    // Validate required fields
+    if (!formData.academicPeriodId) {
+      Swal.fire({
+        title: 'Error',
+        text: 'Please select an academic period',
+        icon: 'error',
+        confirmButtonText: 'Confirm',
+        confirmButtonColor: '#ff0000',
+        confirmButtonTextColor: 'white',
+      });
+      return;
+    }
+
+    // Validate schedule dates are within academic period boundaries
+    if (formData.periodStart && formData.periodEnd) {
+      const selectedPeriod = academicPeriods.find(
+        (p) => p.id === formData.academicPeriodId
+      );
+
+      if (selectedPeriod) {
+        const scheduleStart = new Date(formData.periodStart);
+        const scheduleEnd = new Date(formData.periodEnd);
+        const periodStart = new Date(selectedPeriod.startAt);
+        const periodEnd = new Date(selectedPeriod.endAt);
+
+        if (formData.time_start === '' || formData.time_end === '') {
+          Swal.fire({
+            title: 'Error',
+            text: 'Please select a time',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        if (formData.time_start >= formData.time_end) {
+          Swal.fire({
+            title: 'Error',
+            text: 'Start time must be before end time',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        if (formData.time_start < '06:00') {
+          Swal.fire({
+            title: 'Error',
+            text: 'Earliest Start Time is 6:00 AM',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        if (formData.time_end >= '21:01') {
+          Swal.fire({
+            title: 'Error',
+            text: 'Latest End Time is 9:00 PM',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        // Validate minimum duration of 30 minutes
+        const [startHours, startMinutes] = formData.time_start
+          .split(':')
+          .map(Number);
+        const [endHours, endMinutes] = formData.time_end.split(':').map(Number);
+        const startTotalMinutes = startHours * 60 + startMinutes;
+        const endTotalMinutes = endHours * 60 + endMinutes;
+        const durationMinutes = endTotalMinutes - startTotalMinutes;
+
+        if (durationMinutes < 30) {
+          Swal.fire({
+            title: 'Error',
+            text: 'Schedule duration must be at least 30 minutes',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        if (scheduleStart < periodStart || scheduleEnd > periodEnd) {
+          Swal.fire({
+            title: 'Error',
+            text: `Schedule dates must be within the academic period range:\n${periodStart.toLocaleDateString()} - ${periodEnd.toLocaleDateString()}`,
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+
+        if (scheduleStart > scheduleEnd) {
+          Swal.fire({
+            title: 'Error',
+            text: 'Schedule end date must be after start date',
+            icon: 'error',
+            confirmButtonText: 'Confirm',
+            confirmButtonColor: '#ff0000',
+            confirmButtonTextColor: 'white',
+          });
+          return;
+        }
+      }
+    }
+
+    onSave(formData);
+  };
+
+  const formatRecurrenceDisplay = () => {
+    if (!formData.days || !formData.periodEnd) return '';
+    const dayMap = {
+      M: 'Mon',
+      T: 'Tue',
+      W: 'Wed',
+      TH: 'Thu',
+      F: 'Fri',
+      S: 'Sat',
+      SU: 'Sun',
+    };
+    const daysArray = formData.days
+      .split(',')
+      .map((d) => dayMap[d.trim()] || d.trim());
+    const endDate = new Date(formData.periodEnd).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    return `Every ${daysArray.join(', ')} until ${endDate}`;
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-800">
+              {event ? 'Edit Schedule' : 'Create Schedule'}
+            </h2>
+            {selectedDate && (
+              <p className="text-sm text-gray-500">
+                {selectedDate.toLocaleDateString('en-US', {
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            <MdClose size={24} />
+          </button>
+        </div>
+
+        {/* Form Content */}
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto">
+          <div className="p-6 space-y-4">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Left Column - Form Fields */}
+              <div className="lg:col-span-2 space-y-4">
+                {/* Course Title */}
+                <div className="flex items-start gap-3">
+                  <FaAlignLeft className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Course Title<span className="text-red-500">*</span>
+                    </label>
+                    <CourseSelect
+                      value={formData.courseId}
+                      onChange={handleCourseSelect}
+                      courses={courses}
+                      isLoading={isLoadingCourses}
+                    />
+                  </div>
+                  {/* Color Indicator */}
+                  <div
+                    className="w-6 h-6 rounded-full mt-8 border-2 border-gray-300"
+                    style={{ backgroundColor: formData.color }}
+                  ></div>
+                </div>
+
+                {/* Academic Period */}
+                <div className="flex items-start gap-3">
+                  <MdCalendarToday className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Academic Period <span className="text-red-500">*</span>
+                    </label>
+                    <AcademicPeriodSelect
+                      value={formData.academicPeriodId}
+                      onChange={handleAcademicPeriodSelect}
+                      academicPeriods={academicPeriods}
+                      isLoading={isLoadingAcademicPeriods}
+                    />
+                    {formData.academicPeriodId && (
+                      <p className="text-xs text-gray-500 mt-1">
+                        Schedule dates must be within the academic period range
+                      </p>
+                    )}
+                    {!formData.academicPeriodId && (
+                      <p className="text-xs text-gray-500 mt-1">
+                        Select the academic period this schedule applies to
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Event Location */}
+                <div className="flex items-start gap-3">
+                  <MdLocationOn className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Event Location<span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="location"
+                      value={formData.location}
+                      onChange={handleChange}
+                      placeholder="e.g., Online - VR1"
+                      className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+                    />
+                  </div>
+                </div>
+
+                {/* Time */}
+                <div className="flex items-start gap-3">
+                  <MdAccessTime className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Time<span className="text-red-500">*</span>
+                    </label>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                          Start Time
+                        </label>
+                        <input
+                          type="time"
+                          name="time_start"
+                          value={formData.time_start}
+                          onChange={handleChange}
+                          min="06:00"
+                          className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+                          required
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                          End Time
+                        </label>
+                        <input
+                          type="time"
+                          name="time_end"
+                          value={formData.time_end}
+                          onChange={handleChange}
+                          className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+                          required
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Repeat */}
+                <div className="flex items-start gap-3">
+                  <MdRepeat className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Repeat<span className="text-red-500">*</span>
+                    </label>
+                    <div className="space-y-2">
+                      {/* Day Selection Buttons */}
+                      <div className="flex flex-wrap gap-2">
+                        {[
+                          { value: 'M', label: 'Mon' },
+                          { value: 'T', label: 'Tue' },
+                          { value: 'W', label: 'Wed' },
+                          { value: 'TH', label: 'Thu' },
+                          { value: 'F', label: 'Fri' },
+                          { value: 'S', label: 'Sat' },
+                          { value: 'SU', label: 'Sun' },
+                        ].map((day) => {
+                          const isSelected = formData.days
+                            ? formData.days
+                                .split(',')
+                                .map((d) => d.trim())
+                                .includes(day.value)
+                            : false;
+                          return (
+                            <button
+                              key={day.value}
+                              type="button"
+                              onClick={() => handleDayToggle(day.value)}
+                              className={`px-3 py-2 rounded text-sm font-medium transition-all ${
+                                isSelected
+                                  ? 'bg-dark-red-2 text-white'
+                                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                              }`}
+                            >
+                              {day.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">
+                            Start Date<span className="text-red-500">*</span>
+                          </label>
+                          <input
+                            type="date"
+                            name="periodStart"
+                            value={formData.periodStart}
+                            onChange={handleChange}
+                            className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+                            required
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">
+                            End Date<span className="text-red-500">*</span>
+                          </label>
+                          <input
+                            type="date"
+                            name="periodEnd"
+                            value={formData.periodEnd}
+                            onChange={handleChange}
+                            className="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-dark-red-2"
+                            required
+                          />
+                        </div>
+                      </div>
+                      {formatRecurrenceDisplay() && (
+                        <p className="text-sm text-gray-600 bg-gray-50 p-2 rounded">
+                          {formatRecurrenceDisplay()}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Organizer / Adviser */}
+                <div className="flex items-start gap-3">
+                  <MdPerson className="text-gray-400 mt-3" size={20} />
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Organizer / Adviser<span className="text-red-500">*</span>
+                    </label>
+                    <TeacherSelect
+                      value={formData.teacherId}
+                      onChange={handleTeacherSelect}
+                      teachers={teachers}
+                      isLoading={isLoadingTeachers}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Right Column - Notes & Color Palette */}
+              <div className="space-y-4">
+                {/* Color Palette */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Event Color<span className="text-red-500">*</span>
+                  </label>
+                  <div className="grid grid-cols-5 gap-2">
+                    {colorOptions.map((color) => (
+                      <button
+                        key={color}
+                        type="button"
+                        onClick={() => handleColorSelect(color)}
+                        className={`w-8 h-8 rounded-full border-2 transition-all ${
+                          formData.color === color
+                            ? 'border-gray-800 scale-110'
+                            : 'border-gray-300 hover:scale-105'
+                        }`}
+                        style={{ backgroundColor: color }}
+                      ></button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Notes */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Notes
+                  </label>
+                  <textarea
+                    name="notes"
+                    value={formData.notes}
+                    onChange={handleChange}
+                    placeholder="Add notes, meeting links, or additional information..."
+                    rows={8}
+                    className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-dark-red-2 resize-none"
+                  ></textarea>
+                </div>
+
+                {/* View Students Button (if editing) */}
+                {event && (
+                  <button
+                    type="button"
+                    className="w-full text-sm text-gray-600 hover:text-gray-800 flex items-center justify-center gap-2 py-2 border border-gray-300 rounded hover:bg-gray-50 transition-colors"
+                  >
+                    <MdPerson size={16} />
+                    View Students
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Footer Actions */}
+          <div className="flex items-center justify-between p-4 border-t bg-gray-50">
+            <div>
+              {event && onDelete && (
+                <button
+                  type="button"
+                  onClick={() => onDelete(event)}
+                  className="px-4 py-2 text-gray-700 bg-gray-200 hover:bg-gray-300 rounded transition-colors"
+                >
+                  Delete Event
+                </button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-6 py-2 bg-dark-red-2 hover:bg-dark-red-3 text-white rounded transition-colors"
+              >
+                Save Event
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+CreateEditScheduleModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  event: PropTypes.shape({
+    title: PropTypes.string, // For backward compatibility
+    courseId: PropTypes.string,
+    courseName: PropTypes.string,
+    academicPeriodId: PropTypes.string,
+    academicPeriodName: PropTypes.string,
+    location: PropTypes.string,
+    time_start: PropTypes.string,
+    time_end: PropTypes.string,
+    days: PropTypes.string,
+    periodStart: PropTypes.string,
+    periodEnd: PropTypes.string,
+    teacherId: PropTypes.string,
+    teacherName: PropTypes.string,
+    notes: PropTypes.string,
+    color: PropTypes.string,
+  }),
+  selectedDate: PropTypes.instanceOf(Date),
+  onSave: PropTypes.func.isRequired,
+  onDelete: PropTypes.func,
+  teachers: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      userId: PropTypes.string.isRequired,
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      email: PropTypes.string,
+      status: PropTypes.string,
+    })
+  ),
+  isLoadingTeachers: PropTypes.bool,
+  courses: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      visibility: PropTypes.string,
+    })
+  ),
+  isLoadingCourses: PropTypes.bool,
+  academicPeriods: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      periodName: PropTypes.string.isRequired,
+      batchName: PropTypes.string,
+      startAt: PropTypes.string.isRequired,
+      endAt: PropTypes.string.isRequired,
+      status: PropTypes.string,
+    })
+  ),
+  isLoadingAcademicPeriods: PropTypes.bool,
+};
+
+export default CreateEditScheduleModal;

--- a/client/src/components/modals/schedule/DateSelectModal.js
+++ b/client/src/components/modals/schedule/DateSelectModal.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MdClose } from 'react-icons/md';
+import useAuthStore from '../../../stores/authStore';
+
+/**
+ * Date Select Modal - Shows all events for a selected day
+ * Displays events in a timeline view organized by time slots
+ */
+function DateSelectModal({
+  isOpen,
+  onClose,
+  selectedDate,
+  events,
+  onEventClick,
+}) {
+  const { isAdmin } = useAuthStore();
+
+  if (!isOpen) return null;
+
+  const timeSlots = [
+    '6:00 AM',
+    '7:00 AM',
+    '8:00 AM',
+    '9:00 AM',
+    '10:00 AM',
+    '11:00 AM',
+    '12:00 PM',
+    '1:00 PM',
+    '2:00 PM',
+    '3:00 PM',
+    '4:00 PM',
+    '5:00 PM',
+    '6:00 PM',
+    '7:00 PM',
+    '8:00 PM',
+    '9:00 PM',
+  ];
+
+  const formatDate = (date) => {
+    return date.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getEventsForTimeSlot = (timeSlot) => {
+    return events.filter((event) => {
+      // Convert event time from 24-hour format to 12-hour format for comparison
+      const convertTo12Hour = (time24) => {
+        const [hours, minutes] = time24.split(':').map(Number);
+        const period = hours >= 12 ? 'PM' : 'AM';
+        let hour12 = hours % 12;
+        if (hour12 === 0) hour12 = 12;
+        return `${hour12}:${minutes.toString().padStart(2, '0')} ${period}`;
+      };
+
+      const eventTime12Hour = convertTo12Hour(event.time_start);
+
+      // Check if the event's time matches this time slot
+      return eventTime12Hour === timeSlot;
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold text-gray-800">
+            Date Select Modal
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            <MdClose size={24} />
+          </button>
+        </div>
+
+        {/* Date Display */}
+        <div className="px-4 py-3 border-b">
+          <p className="text-sm text-black font-bold">
+            {formatDate(selectedDate)}
+          </p>
+        </div>
+
+        {/* Timeline Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          <div className="space-y-2">
+            {/* Events Timeline */}
+            <div className="relative">
+              {timeSlots.map((timeSlot, index) => {
+                const slotEvents = getEventsForTimeSlot(timeSlot);
+
+                return (
+                  <div
+                    key={timeSlot}
+                    className="grid grid-cols-[80px_1fr] gap-2 mb-2"
+                  >
+                    {/* Time Label */}
+                    <div className="text-sm font-semibold text-gray-600 text-right pt-2">
+                      {timeSlot}
+                    </div>
+
+                    {/* Events for this time slot */}
+                    <div className="min-h-[60px] space-y-1">
+                      {slotEvents.map((event, eventIndex) => {
+                        // Support both courseName and title for backward compatibility
+                        const displayTitle = event.courseName || event.title;
+
+                        return (
+                          <div
+                            key={eventIndex}
+                            onClick={() => onEventClick(event)}
+                            style={{ backgroundColor: event.color }}
+                            className="p-2 rounded cursor-pointer hover:opacity-80 transition-opacity"
+                          >
+                            <p className="text-sm font-medium text-gray-800 truncate">
+                              {displayTitle}
+                            </p>
+                            <p className="text-xs text-gray-700">
+                              {event.time_start} - {event.time_end}
+                            </p>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer with Add Button - Only visible for admin users */}
+        {isAdmin() && (
+          <div className={`p-4 border-t `}>
+            <button
+              onClick={() => onEventClick(null)} // null indicates creating new event
+              className="w-full bg-dark-red-2 hover:bg-dark-red-3 text-white font-medium py-2 px-4 rounded transition-colors"
+            >
+              + Add New Event
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+DateSelectModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedDate: PropTypes.instanceOf(Date).isRequired,
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string, // For backward compatibility
+      courseName: PropTypes.string, // Preferred field
+      time_start: PropTypes.string.isRequired,
+      time_end: PropTypes.string.isRequired,
+      color: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  onEventClick: PropTypes.func.isRequired,
+};
+
+export default DateSelectModal;

--- a/client/src/components/modals/schedule/ViewStudentsModal.js
+++ b/client/src/components/modals/schedule/ViewStudentsModal.js
@@ -45,7 +45,7 @@ function ViewStudentsModal({
             courseId,
             periodId,
             enrolledOnly: true,
-            take: 100,
+            take: 50,
           },
           signal: controller.signal,
         });
@@ -241,9 +241,10 @@ function ViewStudentsModal({
           </div>
 
           <div className="grid grid-cols-12 text-sm font-semibold border-b pb-2 items-center">
-            <div className="col-span-1">
+            <div className="col-span-1 px-2">
               <input
                 type="checkbox"
+                className="cursor-pointer"
                 checked={
                   selectedIds.length > 0 &&
                   selectedIds.length === allVisibleIds.length
@@ -268,12 +269,13 @@ function ViewStudentsModal({
               <button
                 key={s.id}
                 type="button"
-                onClick={() => handleSelect(s)}
-                className="w-full grid grid-cols-12 items-center py-3 hover:bg-gray-50 text-left"
+                // onClick={() => handleSelect(s)}
+                className="w-full grid grid-cols-12 items-center py-3 hover:bg-gray-50 text-left cursor-default"
               >
                 <div className="col-span-1 px-2">
                   <input
                     type="checkbox"
+                    className="cursor-pointer"
                     checked={selectedIds.includes(s.id)}
                     onChange={(e) => {
                       e.stopPropagation();

--- a/client/src/components/modals/schedule/ViewStudentsModal.js
+++ b/client/src/components/modals/schedule/ViewStudentsModal.js
@@ -1,0 +1,349 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { MdClose } from 'react-icons/md';
+import axiosInstance from '../../../utils/axios';
+import Swal from 'sweetalert2';
+
+function ViewStudentsModal({
+  isOpen,
+  onClose,
+  courseId,
+  periodId,
+  days,
+  time_start,
+  time_end,
+  onStudentSelected,
+  refreshToken,
+  scheduleId,
+}) {
+  const [query, setQuery] = useState('');
+  const [enrolledStudents, setEnrolledStudents] = useState([]);
+  const [enrolledLoading, setEnrolledLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState([]);
+  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+  const [checkingId, setCheckingId] = useState(null);
+  const [selectedIds, setSelectedIds] = useState([]);
+
+  const disabled = useMemo(() => !courseId || !periodId, [courseId, periodId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    setEnrolledStudents([]);
+    setSuggestions([]);
+  }, [isOpen]);
+
+  // Load enrolled students list (main list)
+  useEffect(() => {
+    if (!isOpen || disabled) return;
+    const controller = new AbortController();
+    (async () => {
+      try {
+        setEnrolledLoading(true);
+        const resp = await axiosInstance.get(`/users/search-students`, {
+          params: {
+            courseId,
+            periodId,
+            enrolledOnly: true,
+            take: 100,
+          },
+          signal: controller.signal,
+        });
+        setEnrolledStudents(Array.isArray(resp.data) ? resp.data : []);
+        setSelectedIds([]);
+      } catch (e) {
+        if (e.name !== 'CanceledError') {
+          setEnrolledStudents([]);
+        }
+      } finally {
+        setEnrolledLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [isOpen, courseId, periodId, disabled, refreshToken]);
+
+  // Autocomplete suggestions as user types
+  useEffect(() => {
+    if (!isOpen || disabled) return;
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      if (!query) {
+        setSuggestions([]);
+        return;
+      }
+      try {
+        setSuggestionsLoading(true);
+        const resp = await axiosInstance.get(`/users/search-students`, {
+          params: {
+            q: query,
+            courseId,
+            periodId,
+            take: 10,
+          },
+          signal: controller.signal,
+        });
+        setSuggestions(Array.isArray(resp.data) ? resp.data : []);
+      } catch (e) {
+        if (e.name !== 'CanceledError') {
+          setSuggestions([]);
+        }
+      } finally {
+        setSuggestionsLoading(false);
+      }
+    }, 250);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [isOpen, query, courseId, periodId, disabled]);
+
+  const handleSelect = async (student) => {
+    if (!days || !time_start || !time_end) {
+      onStudentSelected?.({ student, conflict: null });
+      return;
+    }
+    try {
+      setCheckingId(student.id);
+      const resp = await axiosInstance.post('/users/students/conflicts', {
+        studentId: student.id,
+        periodId,
+        days,
+        time_start,
+        time_end,
+      });
+      onStudentSelected?.({ student, conflict: resp.data });
+    } catch (e) {
+      onStudentSelected?.({ student, conflict: { hasConflicts: false } });
+    } finally {
+      setCheckingId(null);
+    }
+  };
+
+  const toggleSelected = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const allVisibleIds = useMemo(
+    () => enrolledStudents.map((s) => s.id),
+    [enrolledStudents]
+  );
+
+  const toggleSelectAll = () => {
+    setSelectedIds((prev) =>
+      prev.length === allVisibleIds.length ? [] : allVisibleIds
+    );
+  };
+
+  const handleBatchDelete = async () => {
+    if (!scheduleId || selectedIds.length === 0) return;
+    const result = await Swal.fire({
+      title: 'Remove selected students?',
+      text: 'This will detach them from this schedule.',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Yes, remove',
+      cancelButtonText: 'Cancel',
+      confirmButtonColor: '#992525',
+    });
+    if (!result.isConfirmed) return;
+    try {
+      await axiosInstance.post(
+        `/schedules/${scheduleId}/students:batch-delete`,
+        {
+          userIds: selectedIds,
+        }
+      );
+      setSelectedIds([]);
+      // trigger refresh from parent via refreshToken or local reload
+      const controller = new AbortController();
+      setEnrolledLoading(true);
+      const resp = await axiosInstance.get(`/users/search-students`, {
+        params: { courseId, periodId, enrolledOnly: true, take: 100 },
+        signal: controller.signal,
+      });
+      setEnrolledStudents(Array.isArray(resp.data) ? resp.data : []);
+    } catch (e) {
+      // swallow
+    } finally {
+      setEnrolledLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="text-lg font-semibold">List of Students</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+          >
+            <MdClose size={22} />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <div className="flex items-center gap-2 mb-3 relative">
+            <button
+              type="button"
+              className="px-3 py-2 bg-dark-red-2 text-white rounded disabled:opacity-50"
+              disabled
+            >
+              Import CSV
+            </button>
+            <input
+              type="text"
+              placeholder="Search by ID, Name, or Email"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              disabled={disabled}
+            />
+            {query && (
+              <div className="absolute left-[120px] right-20 top-12 z-10 bg-white border border-gray-200 rounded shadow max-h-64 overflow-y-auto">
+                {suggestionsLoading && (
+                  <div className="px-3 py-2 text-sm text-gray-500">
+                    Searching…
+                  </div>
+                )}
+                {!suggestionsLoading && suggestions.length === 0 && (
+                  <div className="px-3 py-2 text-sm text-gray-500">
+                    No matches
+                  </div>
+                )}
+                {!suggestionsLoading &&
+                  suggestions.map((s) => (
+                    <button
+                      key={`sugg-${s.id}`}
+                      type="button"
+                      onClick={() => handleSelect(s)}
+                      className="w-full text-left px-3 py-2 hover:bg-gray-50"
+                    >
+                      <div className="text-sm font-medium">{s.name}</div>
+                      <div className="text-xs text-gray-500">
+                        {s.userId} • {s.email}
+                      </div>
+                    </button>
+                  ))}
+              </div>
+            )}
+            <button
+              type="button"
+              className="px-3 py-2 bg-dark-red-2 text-white rounded disabled:opacity-50"
+              disabled
+            >
+              +
+            </button>
+          </div>
+
+          <div className="grid grid-cols-12 text-sm font-semibold border-b pb-2 items-center">
+            <div className="col-span-1">
+              <input
+                type="checkbox"
+                checked={
+                  selectedIds.length > 0 &&
+                  selectedIds.length === allVisibleIds.length
+                }
+                onChange={toggleSelectAll}
+              />
+            </div>
+            <div className="col-span-2">Student ID</div>
+            <div className="col-span-5">Name</div>
+            <div className="col-span-3">Email</div>
+            <div className="col-span-1 text-right">Enrolled</div>
+          </div>
+
+          <div className="divide-y overflow-y-auto max-h-[50vh]">
+            {enrolledLoading && (
+              <div className="py-6 text-center text-gray-500">Loading...</div>
+            )}
+            {!enrolledLoading && enrolledStudents.length === 0 && (
+              <div className="py-6 text-center text-gray-500">No results</div>
+            )}
+            {enrolledStudents.map((s, idx) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => handleSelect(s)}
+                className="w-full grid grid-cols-12 items-center py-3 hover:bg-gray-50 text-left"
+              >
+                <div className="col-span-1 px-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(s.id)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      toggleSelected(s.id);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+                <div className="col-span-2">{s.userId || idx + 1}</div>
+                <div className="col-span-5">{s.name}</div>
+                <div className="col-span-3">{s.email}</div>
+                <div className="col-span-1 text-right">
+                  <span
+                    className={`inline-block px-2 py-1 rounded text-xs ${
+                      s.enrolledInCourse
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {s.enrolledInCourse ? 'Yes' : 'No'}
+                  </span>
+                </div>
+                {checkingId === s.id && (
+                  <div className="col-span-12 text-xs text-gray-500 pl-2">
+                    Checking conflicts…
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="p-4 border-t flex flex-row gap-4">
+          <button
+            type="button"
+            className="px-4 py-2 bg-dark-red-2 text-white rounded h-10"
+            onClick={onClose}
+          >
+            Close
+          </button>
+
+          {selectedIds.length > 0 && (
+            <div className="flex flex-row items-center gap-2">
+              <button
+                type="button"
+                onClick={handleBatchDelete}
+                className="px-4 py-2 bg-dark-red-2 text-white rounded h-10"
+                disabled={!scheduleId}
+              >
+                Remove Selected
+              </button>
+              <p className="text-xs">{selectedIds.length} selected</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ViewStudentsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  courseId: PropTypes.string,
+  periodId: PropTypes.string,
+  days: PropTypes.string,
+  time_start: PropTypes.string,
+  time_end: PropTypes.string,
+  onStudentSelected: PropTypes.func,
+  refreshToken: PropTypes.number,
+};
+
+export default ViewStudentsModal;

--- a/client/src/components/tables/PeriodDetailsTable.js
+++ b/client/src/components/tables/PeriodDetailsTable.js
@@ -1,14 +1,141 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ThinRedButton from '../buttons/ThinRedButton';
+import CreateEditScheduleModal from '../modals/schedule/CreateEditScheduleModal';
+import axiosInstance from '../../utils/axios';
+import { useEnrollmentPeriodStore } from '../../stores/enrollmentPeriodStore';
 
 //Table after clicking a result from enrollment period
-function PeriodDetailsTable({ 
-  periodCourses, 
-  onDeleteCourse, 
+function PeriodDetailsTable({
+  periodCourses,
+  onDeleteCourse,
   selectedPeriod,
   onAddCourse,
-  onBack
+  onBack,
 }) {
+  const [showScheduleModal, setShowScheduleModal] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [teachers, setTeachers] = useState([]);
+  const [isLoadingTeachers, setIsLoadingTeachers] = useState(false);
+  const [courses, setCourses] = useState([]);
+  const [isLoadingCourses, setIsLoadingCourses] = useState(false);
+  const [academicPeriods, setAcademicPeriods] = useState([]);
+  const [isLoadingAcademicPeriods, setIsLoadingAcademicPeriods] =
+    useState(false);
+
+  useEffect(() => {
+    const fetchTeachers = async () => {
+      setIsLoadingTeachers(true);
+      try {
+        const resp = await axiosInstance.get(
+          '/users?role=teacher&status=active'
+        );
+        setTeachers(resp.data?.data || resp.data || []);
+      } catch (e) {
+        setTeachers([]);
+      } finally {
+        setIsLoadingTeachers(false);
+      }
+    };
+
+    const fetchCourses = async () => {
+      setIsLoadingCourses(true);
+      try {
+        const resp = await axiosInstance.get('/courses');
+        setCourses(Array.isArray(resp.data) ? resp.data : []);
+      } catch (e) {
+        setCourses([]);
+      } finally {
+        setIsLoadingCourses(false);
+      }
+    };
+
+    const fetchPeriods = async () => {
+      setIsLoadingAcademicPeriods(true);
+      try {
+        const resp = await axiosInstance.get('/academic-periods');
+        const visible = (resp.data || [])
+          .filter((p) => p && !p.deletedAt)
+          .sort((a, b) => new Date(b.startAt) - new Date(a.startAt));
+        setAcademicPeriods(visible);
+      } catch (e) {
+        setAcademicPeriods([]);
+      } finally {
+        setIsLoadingAcademicPeriods(false);
+      }
+    };
+
+    fetchTeachers();
+    fetchCourses();
+    fetchPeriods();
+  }, []);
+
+  const handleOpenManage = (s) => {
+    const toYmd = (val) => {
+      if (!val) return '';
+      if (typeof val === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(val))
+        return val;
+      const d = new Date(val);
+      if (Number.isNaN(d.getTime())) return '';
+      return d.toISOString().split('T')[0];
+    };
+    const toHm = (val) => {
+      if (!val) return '';
+      if (typeof val === 'string' && /^\d{2}:\d{2}$/.test(val)) return val;
+      if (typeof val === 'string' && /^\d{2}:\d{2}:\d{2}/.test(val))
+        return val.slice(0, 5);
+      return String(val).slice(0, 5);
+    };
+    const event = {
+      id: s.id,
+      courseId: s.course?.id || '',
+      courseName: s.course?.name || '',
+      academicPeriodId: selectedPeriod?.id || '',
+      academicPeriodName: `${selectedPeriod?.periodName || ''}${
+        selectedPeriod?.batchName ? ` - ${selectedPeriod.batchName}` : ''
+      }`,
+      teacherId: s.teacher?.id || '',
+      teacherName: s.teacher
+        ? `${s.teacher.firstName} ${s.teacher.lastName}`
+        : '',
+      location: s.location || '',
+      time_start: toHm(s.time_start),
+      time_end: toHm(s.time_end),
+      days: s.days || '',
+      periodStart: toYmd(s.periodStart),
+      periodEnd: toYmd(s.periodEnd),
+      notes: s.notes || '',
+      color: s.color || '#FFCF00',
+    };
+    setSelectedEvent(event);
+    setShowScheduleModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowScheduleModal(false);
+    setSelectedEvent(null);
+  };
+
+  const handleSaveEvent = async (eventData) => {
+    try {
+      if (selectedEvent?.id) {
+        await axiosInstance.put(`/schedules/${selectedEvent.id}`, eventData);
+      } else {
+        await axiosInstance.post('/schedules', eventData);
+      }
+      const { fetchPeriodCourses } = useEnrollmentPeriodStore.getState();
+      await fetchPeriodCourses();
+      handleCloseModal();
+    } catch (e) {}
+  };
+
+  const handleDeleteEvent = async (event) => {
+    try {
+      await axiosInstance.delete(`/schedules/${event.id}`);
+      const { fetchPeriodCourses } = useEnrollmentPeriodStore.getState();
+      await fetchPeriodCourses();
+      handleCloseModal();
+    } catch (e) {}
+  };
   return (
     <div className="flex flex-col bg-white border-dark-red-2 border-2 rounded-lg p-4 sm:p-5">
       <div className="flex justify-between items-center pb-4 border-b-2 border-dark-red-2">
@@ -34,7 +161,7 @@ function PeriodDetailsTable({
           </svg>
         </button>
       </div>
-      
+
       <div className="mt-4">
         <p className="text-lg sm:text-xl uppercase text-center mb-4">
           {selectedPeriod.periodName} - {selectedPeriod.batchName} (
@@ -49,7 +176,7 @@ function PeriodDetailsTable({
                   Course
                 </th>
                 <th className="py-2 sm:py-3 font-semibold text-center text-sm sm:text-base">
-                  Schedule
+                  Schedules
                 </th>
                 <th className="py-2 sm:py-3 font-semibold text-center text-sm sm:text-base">
                   No. of Students Enrolled
@@ -64,13 +191,47 @@ function PeriodDetailsTable({
                 periodCourses.map((course) => (
                   <tr
                     key={course.id}
-                    className="border-b border-[rgb(137,14,7,.49)] hover:bg-gray-50"
+                    className="border-b border-[rgb(137,14,7,.49)] hover:bg-gray-50 align-top"
                   >
                     <td className="py-2 sm:py-3 text-center text-sm sm:text-base">
                       {course.course}
                     </td>
-                    <td className="py-2 sm:py-3 text-center text-sm sm:text-base">
-                      {course.schedule}
+                    <td className="py-2 sm:py-3 text-left text-sm sm:text-base">
+                      {Array.isArray(course.schedules) &&
+                      course.schedules.length > 0 ? (
+                        <div className="flex flex-col gap-2">
+                          {course.schedules.map((s) => (
+                            <div
+                              key={s.id}
+                              className="flex items-center justify-between gap-2 p-2 rounded border border-gray-200"
+                            >
+                              <div className="text-xs sm:text-sm">
+                                <div className="font-medium">
+                                  {s.days} • {s.time_start} - {s.time_end}
+                                </div>
+                                <div className="text-gray-500">
+                                  {s.teacher?.firstName && s.teacher?.lastName
+                                    ? `${s.teacher.firstName} ${s.teacher.lastName}`
+                                    : ''}
+                                  {s.location
+                                    ? (s.teacher ? ' • ' : '') + s.location
+                                    : ''}
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => handleOpenManage(s)}
+                                className="text-dark-red-2 hover:underline text-xs sm:text-sm whitespace-nowrap"
+                                title="Manage schedule"
+                              >
+                                Manage
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-gray-500">No schedules</span>
+                      )}
                     </td>
                     <td className="py-2 sm:py-3 text-center text-sm sm:text-base">
                       {course.enrolledStudents}
@@ -102,10 +263,23 @@ function PeriodDetailsTable({
       </div>
 
       <div className="mt-4">
-        <ThinRedButton onClick={onBack}>
-          Back to Results
-        </ThinRedButton>
+        <ThinRedButton onClick={onBack}>Back to Results</ThinRedButton>
       </div>
+
+      <CreateEditScheduleModal
+        isOpen={showScheduleModal}
+        onClose={handleCloseModal}
+        event={selectedEvent}
+        selectedDate={null}
+        onSave={handleSaveEvent}
+        onDelete={handleDeleteEvent}
+        teachers={teachers}
+        isLoadingTeachers={isLoadingTeachers}
+        courses={courses}
+        isLoadingCourses={isLoadingCourses}
+        academicPeriods={academicPeriods}
+        isLoadingAcademicPeriods={isLoadingAcademicPeriods}
+      />
     </div>
   );
 }

--- a/client/src/pages/admin/EnrollmentPeriod.js
+++ b/client/src/pages/admin/EnrollmentPeriod.js
@@ -1,16 +1,19 @@
-import React, { useEffect } from "react";
-import ThinRedButton from "../../components/buttons/ThinRedButton";
-import AddCourseModal from "../../components/modals/enrollment/AddCourseModal";
-import AcademicPeriodModal from "../../components/modals/enrollment/AddAcademicPeriodModal";
-import PeriodDetailsTable from "../../components/tables/PeriodDetailsTable";
-import SearchForm from "../../components/common/SearchFormHorizontal";
-import SearchResults from "../../components/common/SearchResults";
-import { useEnrollmentPeriodSearchStore, useEnrollmentPeriodStore } from "../../stores/enrollmentPeriodStore";
+import React, { useEffect } from 'react';
+import ThinRedButton from '../../components/buttons/ThinRedButton';
+import AddCourseModal from '../../components/modals/enrollment/AddCourseModal';
+import AcademicPeriodModal from '../../components/modals/enrollment/AddAcademicPeriodModal';
+import PeriodDetailsTable from '../../components/tables/PeriodDetailsTable';
+import SearchForm from '../../components/common/SearchFormHorizontal';
+import SearchResults from '../../components/common/SearchResults';
+import {
+  useEnrollmentPeriodSearchStore,
+  useEnrollmentPeriodStore,
+} from '../../stores/enrollmentPeriodStore';
 
 function EnrollmentPeriod() {
   // Search store
   const searchStore = useEnrollmentPeriodSearchStore();
-  
+
   // Main store
   const {
     selectedPeriod,
@@ -24,76 +27,78 @@ function EnrollmentPeriod() {
     handlePeriodSelect,
     handleBackToResults,
     deleteCourse,
-    resetStore
+    resetStore,
   } = useEnrollmentPeriodStore();
 
   useEffect(() => {
     fetchPeriods();
     searchStore.initializeSearch();
-    
+
     return () => {
       resetStore();
       searchStore.resetSearch();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     if (selectedPeriod) {
       fetchPeriodCourses();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPeriod]);
 
   const searchFormConfig = {
-    title: "SEARCH ENROLLMENT PERIOD",
+    title: 'SEARCH ENROLLMENT PERIOD',
     formFields: [
       {
-        name: "periodName",
-        label: "Period",
-        placeholder: "Search Period...",
-        type: "text",
-        fullWidth: true
+        name: 'periodName',
+        label: 'Period',
+        placeholder: 'Search Period...',
+        type: 'text',
+        fullWidth: true,
       },
       {
-        name: "batch",
-        label: "Batch",
-        type: "select",
+        name: 'batch',
+        label: 'Batch',
+        type: 'select',
         options: [
-          { value: "", label: "All Batches" },
-          { value: "Batch 1", label: "Batch 1" },
-          { value: "Batch 2", label: "Batch 2" },
-          { value: "Batch 3", label: "Batch 3" }
-        ]
+          { value: '', label: 'All Batches' },
+          { value: 'Batch 1', label: 'Batch 1' },
+          { value: 'Batch 2', label: 'Batch 2' },
+          { value: 'Batch 3', label: 'Batch 3' },
+        ],
       },
       {
-        name: "year",
-        label: "Year",
-        type: "select",
+        name: 'year',
+        label: 'Year',
+        type: 'select',
         options: [
-          { value: "", label: "All Years" },
-          { value: "2024", label: "2024" },
-          { value: "2023", label: "2023" },
-          { value: "2022", label: "2022" }
-        ]
+          { value: '', label: 'All Years' },
+          { value: '2024', label: '2024' },
+          { value: '2023', label: '2023' },
+          { value: '2022', label: '2022' },
+        ],
       },
       {
-        name: "status",
-        label: "Status",
-        type: "select",
+        name: 'status',
+        label: 'Status',
+        type: 'select',
         options: [
-          { value: "", label: "All Statuses" },
-          { value: "Ongoing", label: "Ongoing" },
-          { value: "Ended", label: "Ended" },
-          { value: "Upcoming", label: "Upcoming" }
-        ]
-      }
-    ]
+          { value: '', label: 'All Statuses' },
+          { value: 'Ongoing', label: 'Ongoing' },
+          { value: 'Ended', label: 'Ended' },
+          { value: 'Upcoming', label: 'Upcoming' },
+        ],
+      },
+    ],
   };
 
   const searchResultsColumns = [
-    { key: "periodName", header: "Period" },
-    { key: "batchName", header: "Batch" },
-    { key: "year", header: "Year" },
-    { key: "status", header: "Status" }
+    { key: 'periodName', header: 'Period' },
+    { key: 'batchName', header: 'Batch' },
+    { key: 'year', header: 'Year' },
+    { key: 'status', header: 'Status' },
   ];
 
   const paginationConfig = {
@@ -103,12 +108,12 @@ function EnrollmentPeriod() {
     itemsPerPage: searchStore.itemsPerPage,
     onItemsPerPageChange: searchStore.handleItemsPerPageChange,
     totalItems: searchStore.totalItems,
-    itemName: "periods",
-    showItemsPerPageSelector: true
+    itemName: 'periods',
+    showItemsPerPageSelector: true,
   };
 
   const handleSearch = () => searchStore.handleSearch();
-  
+
   const handlePeriodClick = (period) => {
     handlePeriodSelect(period);
   };
@@ -117,10 +122,14 @@ function EnrollmentPeriod() {
     switch (status) {
       case 'Ongoing':
         return 'bg-green-100 text-green-800 border border-green-200';
+      case 'Ongoing (Enrollment Closed)':
+        return 'bg-yellow-100 text-yellow-800 border border-yellow-200';
       case 'Ended':
         return 'bg-red-100 text-red-800 border border-red-200';
       case 'Upcoming':
         return 'bg-blue-100 text-blue-800 border border-blue-200';
+      case 'Upcoming (Enrollment Closed)':
+        return 'bg-orange-100 text-orange-800 border border-orange-200';
       default:
         return 'bg-gray-100 text-gray-800 border border-gray-200';
     }
@@ -144,7 +153,7 @@ function EnrollmentPeriod() {
       )}
 
       {/* Search Form */}
-      <SearchForm 
+      <SearchForm
         searchLogic={searchStore}
         fields={searchFormConfig}
         onSearch={handleSearch}
@@ -159,13 +168,23 @@ function EnrollmentPeriod() {
         pagination={paginationConfig}
         columnRenderers={{
           status: (status) => (
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeColor(status)}`}>
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeColor(
+                status
+              )}`}
+            >
               {status}
             </span>
-          )
+          ),
         }}
         actionButton={
-          <ThinRedButton onClick={() => useEnrollmentPeriodStore.setState({ addAcademicPeriodModal: true })}>
+          <ThinRedButton
+            onClick={() =>
+              useEnrollmentPeriodStore.setState({
+                addAcademicPeriodModal: true,
+              })
+            }
+          >
             Create Period
           </ThinRedButton>
         }
@@ -177,7 +196,9 @@ function EnrollmentPeriod() {
           periodCourses={periodCourses}
           onDeleteCourse={deleteCourse}
           selectedPeriod={selectedPeriod}
-          onAddCourse={() => useEnrollmentPeriodStore.setState({ addCourseModal: true })}
+          onAddCourse={() =>
+            useEnrollmentPeriodStore.setState({ addCourseModal: true })
+          }
           onBack={handleBackToResults}
         />
       )}
@@ -185,13 +206,17 @@ function EnrollmentPeriod() {
       {/* Modals */}
       <AddCourseModal
         add_course_modal={addCourseModal}
-        setAddCourseModal={(show) => useEnrollmentPeriodStore.setState({ addCourseModal: show })}
+        setAddCourseModal={(show) =>
+          useEnrollmentPeriodStore.setState({ addCourseModal: show })
+        }
         selectedPeriod={selectedPeriod}
         fetchPeriodCourses={fetchPeriodCourses}
       />
       <AcademicPeriodModal
         addAcademicPeriodModal={addAcademicPeriodModal}
-        setAddAcademicPeriodModal={(show) => useEnrollmentPeriodStore.setState({ addAcademicPeriodModal: show })}
+        setAddAcademicPeriodModal={(show) =>
+          useEnrollmentPeriodStore.setState({ addAcademicPeriodModal: show })
+        }
         fetchPeriods={fetchPeriods}
       />
     </div>

--- a/client/src/pages/admin/Schedule.js
+++ b/client/src/pages/admin/Schedule.js
@@ -256,7 +256,17 @@ function AdminSchedule() {
 
   // Handler for deleting an event
   const handleDeleteEvent = async (event) => {
-    if (window.confirm('Are you sure you want to delete this event?')) {
+    Swal.fire({
+      title: 'Are you sure you want to delete this event?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Delete',
+      confirmButtonColor: '#992525',
+      cancelButtonText: 'Cancel',
+      cancelButtonColor: '#6b7280',
+    }).then(async (result) => {
+      if (!result.isConfirmed) return;
+
       try {
         await axiosInstance.delete(`/schedules/${event.id}`);
 
@@ -273,12 +283,12 @@ function AdminSchedule() {
             error.response?.data?.message ||
             'Failed to delete schedule. Please try again.',
           icon: 'error',
-          confirmButtonText: 'Confirm',
+          confirmButtonText: 'OK',
           confirmButtonColor: '#000000',
           confirmButtonTextColor: 'white',
         });
       }
-    }
+    });
   };
 
   // Handler for closing modals

--- a/client/src/pages/admin/Schedule.js
+++ b/client/src/pages/admin/Schedule.js
@@ -1,0 +1,335 @@
+import React, { useState, useEffect } from 'react';
+import Calendar from '../../components/calendar/Calendar';
+import Spinner from '../../components/common/Spinner';
+import DateSelectModal from '../../components/modals/schedule/DateSelectModal';
+import CreateEditScheduleModal from '../../components/modals/schedule/CreateEditScheduleModal';
+import axiosInstance from '../../utils/axios';
+import Swal from 'sweetalert2';
+// import { transformScheduleToEvent } from '../../utils/scheduleExamples';
+
+/**
+ * Admin Schedule Page
+ *
+ * This component displays the calendar with recurring schedule events.
+ * Events are defined with a 'days' field (e.g., "M,W,F" or "T,TH") and will
+ * automatically appear on matching days without needing separate entries per date.
+ *
+ * To use with API data:
+ * 1. Fetch schedules from your API endpoint (e.g., /api/schedules)
+ * 2. Transform each schedule using transformScheduleToEvent() from scheduleExamples.js
+ * 3. Pass the transformed events to the Calendar component
+ *
+ * Example:
+ * const [schedules, setSchedules] = useState([]);
+ * const [isLoading, setIsLoading] = useState(true);
+ *
+ * useEffect(() => {
+ *   setIsLoading(true);
+ *   fetch('/api/v1/schedules')
+ *     .then(res => res.json())
+ *     .then(data => {
+ *       const events = data.schedules.map(schedule => transformScheduleToEvent(schedule));
+ *       setSchedules(events);
+ *     })
+ *     .catch(error => console.error('Error fetching schedules:', error))
+ *     .finally(() => setIsLoading(false));
+ * }, []);
+ *
+ * return isLoading ? <Spinner /> : <Calendar events={schedules} />;
+ */
+function AdminSchedule() {
+  const [schedules, setSchedules] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [teachers, setTeachers] = useState([]);
+  const [isLoadingTeachers, setIsLoadingTeachers] = useState(false);
+  const [courses, setCourses] = useState([]);
+  const [isLoadingCourses, setIsLoadingCourses] = useState(false);
+  const [academicPeriods, setAcademicPeriods] = useState([]);
+  const [isLoadingAcademicPeriods, setIsLoadingAcademicPeriods] =
+    useState(false);
+
+  // Modal states
+  const [showDateSelectModal, setShowDateSelectModal] = useState(false);
+  const [showCreateEditModal, setShowCreateEditModal] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(null);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [eventsForSelectedDate, setEventsForSelectedDate] = useState([]);
+
+  // Fetch teachers list
+  useEffect(() => {
+    const fetchTeachers = async () => {
+      setIsLoadingTeachers(true);
+      try {
+        const response = await axiosInstance.get(
+          '/users?role=teacher&status=active'
+        );
+
+        // API returns { data: users[], count, max_result, page, max_page }
+        const users = response.data?.data || response.data;
+
+        if (!users || !Array.isArray(users)) {
+          throw new Error('Invalid response format from server');
+        }
+        setTeachers(users);
+      } catch (error) {
+        console.error('Error fetching teachers:', error);
+        setTeachers([]);
+      } finally {
+        setIsLoadingTeachers(false);
+      }
+    };
+
+    fetchTeachers();
+  }, []);
+
+  // Fetch courses list
+  useEffect(() => {
+    const fetchCourses = async () => {
+      setIsLoadingCourses(true);
+      try {
+        const response = await axiosInstance.get('/courses');
+
+        if (!response.data || !Array.isArray(response.data)) {
+          throw new Error('Invalid response format from server');
+        }
+
+        setCourses(response.data);
+      } catch (error) {
+        console.error('Error fetching courses:', error);
+        setCourses([]);
+      } finally {
+        setIsLoadingCourses(false);
+      }
+    };
+
+    fetchCourses();
+  }, []);
+
+  // Fetch academic periods
+  useEffect(() => {
+    const fetchAcademicPeriods = async () => {
+      setIsLoadingAcademicPeriods(true);
+      try {
+        const response = await axiosInstance.get('/academic-periods');
+
+        if (!response.data || !Array.isArray(response.data)) {
+          throw new Error('Invalid response format from server');
+        }
+
+        const visiblePeriods = response.data
+          .filter((period) => period && !period.deletedAt)
+          .map((period) => {
+            const now = new Date();
+            const startDate = new Date(period.startAt);
+            const endDate = new Date(period.endAt);
+
+            // Calculate actual period status based on dates
+            let periodStatus;
+            if (now < startDate) {
+              periodStatus = 'Upcoming';
+            } else if (now >= startDate && now <= endDate) {
+              periodStatus = 'Ongoing';
+            } else {
+              periodStatus = 'Ended';
+            }
+
+            // Determine enrollment status
+            const enrollmentOpen =
+              period.status === 'ongoing' || period.status === 'upcoming';
+
+            // Display status combines both period and enrollment info
+            let displayStatus;
+            if (periodStatus === 'Ended') {
+              displayStatus = 'Ended';
+            } else if (periodStatus === 'Ongoing') {
+              displayStatus = enrollmentOpen
+                ? 'Ongoing'
+                : 'Ongoing (Enrollment Closed)';
+            } else {
+              // Upcoming
+              displayStatus = enrollmentOpen
+                ? 'Upcoming'
+                : 'Upcoming (Enrollment Closed)';
+            }
+
+            return {
+              ...period,
+              id: period.id,
+              periodName: period.periodName,
+              batchName: period.batchName,
+              startAt: period.startAt,
+              endAt: period.endAt,
+              status: displayStatus,
+              periodStatus: periodStatus, // The actual period status
+              enrollmentOpen: enrollmentOpen, // Whether enrollment is open
+            };
+          })
+          .sort((a, b) => new Date(b.startAt) - new Date(a.startAt));
+
+        setAcademicPeriods(visiblePeriods);
+      } catch (error) {
+        console.error('Failed to fetch academic periods:', error);
+        setAcademicPeriods([]);
+      } finally {
+        setIsLoadingAcademicPeriods(false);
+      }
+    };
+
+    fetchAcademicPeriods();
+  }, []);
+
+  // Fetch schedules from API
+  useEffect(() => {
+    const fetchSchedules = async () => {
+      setIsLoading(true);
+      try {
+        const response = await axiosInstance.get('/schedules');
+
+        if (!response.data || !Array.isArray(response.data)) {
+          throw new Error('Invalid response format from server');
+        }
+
+        // Data is already transformed by the backend
+        setSchedules(response.data);
+      } catch (error) {
+        console.error('Error fetching schedules:', error);
+        setSchedules([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchSchedules();
+  }, []);
+
+  // Handler for clicking on a date/time in the calendar
+  const handleDateTimeClick = (date, eventsForDate) => {
+    setSelectedDate(date);
+    setEventsForSelectedDate(eventsForDate);
+    setShowDateSelectModal(true);
+  };
+
+  // Handler for clicking on an event in the DateSelectModal
+  const handleEventClick = (event) => {
+    setSelectedEvent(event);
+    setShowDateSelectModal(false);
+    setShowCreateEditModal(true);
+  };
+
+  // Handler for saving an event
+  const handleSaveEvent = async (eventData) => {
+    try {
+      if (selectedEvent) {
+        // Update existing event
+        const response = await axiosInstance.put(
+          `/schedules/${selectedEvent.id}`,
+          eventData
+        );
+
+        setSchedules((prev) =>
+          prev.map((schedule) =>
+            schedule.id === selectedEvent.id ? response.data : schedule
+          )
+        );
+      } else {
+        // Create new event
+        const response = await axiosInstance.post('/schedules', eventData);
+        setSchedules((prev) => [...prev, response.data]);
+      }
+
+      setShowCreateEditModal(false);
+      setSelectedEvent(null);
+    } catch (error) {
+      console.error('Error saving schedule:', error);
+      Swal.fire({
+        title: 'Error',
+        text:
+          error.response?.data?.message ||
+          'Failed to save schedule. Please try again.',
+        icon: 'error',
+        confirmButtonText: 'Confirm',
+        confirmButtonColor: '#000000',
+        confirmButtonTextColor: 'white',
+      });
+    }
+  };
+
+  // Handler for deleting an event
+  const handleDeleteEvent = async (event) => {
+    if (window.confirm('Are you sure you want to delete this event?')) {
+      try {
+        await axiosInstance.delete(`/schedules/${event.id}`);
+
+        setSchedules((prev) =>
+          prev.filter((schedule) => schedule.id !== event.id)
+        );
+        setShowCreateEditModal(false);
+        setSelectedEvent(null);
+      } catch (error) {
+        console.error('Error deleting schedule:', error);
+        Swal.fire({
+          title: 'Error',
+          text:
+            error.response?.data?.message ||
+            'Failed to delete schedule. Please try again.',
+          icon: 'error',
+          confirmButtonText: 'Confirm',
+          confirmButtonColor: '#000000',
+          confirmButtonTextColor: 'white',
+        });
+      }
+    }
+  };
+
+  // Handler for closing modals
+  const handleCloseModals = () => {
+    setShowDateSelectModal(false);
+    setShowCreateEditModal(false);
+    setSelectedEvent(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col justify-center items-center min-h-screen">
+        <Spinner
+          size="xl"
+          color="text-dark-red-2"
+          message="Loading schedule data..."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <Calendar events={schedules} onDateTimeClick={handleDateTimeClick} />
+
+      {/* Date Select Modal */}
+      <DateSelectModal
+        isOpen={showDateSelectModal}
+        onClose={handleCloseModals}
+        selectedDate={selectedDate}
+        events={eventsForSelectedDate}
+        onEventClick={handleEventClick}
+      />
+
+      {/* Create/Edit Schedule Modal */}
+      <CreateEditScheduleModal
+        isOpen={showCreateEditModal}
+        onClose={handleCloseModals}
+        event={selectedEvent}
+        selectedDate={selectedDate}
+        onSave={handleSaveEvent}
+        onDelete={handleDeleteEvent}
+        teachers={teachers}
+        isLoadingTeachers={isLoadingTeachers}
+        courses={courses}
+        isLoadingCourses={isLoadingCourses}
+        academicPeriods={academicPeriods}
+        isLoadingAcademicPeriods={isLoadingAcademicPeriods}
+      />
+    </div>
+  );
+}
+
+export default AdminSchedule;

--- a/client/src/pages/public/Login.js
+++ b/client/src/pages/public/Login.js
@@ -161,6 +161,7 @@ function Login() {
                   }}
                 />
                 <button
+                  type="button"
                   className="absolute top-1/2 right-3 transform -translate-y-1/2"
                   onClick={(e) => {
                     e.preventDefault();
@@ -220,9 +221,9 @@ function Login() {
             </form>
 
             {/* New Student and Enrollment Tracker Area */}
-            <div className="container flex items-center justify-center mt-20">
-              <div className="flex flex-col items-center justify-center w-1/3">
-                <p className="text-white-yellow-tone text-sm -mb-4 font-sans">
+            <div className="container flex items-center justify-center mt-20 mr-8 lg:mr-0">
+              <div className="flex flex-col w-1/2 lg:w-1/3">
+                <p className="text-white-yellow-tone text-xs font-sans -mb-3 px-2">
                   New Student?
                 </p>
                 <SecondaryButton onClick={() => navigate('/sign-up')}>
@@ -230,8 +231,8 @@ function Login() {
                 </SecondaryButton>
               </div>
 
-              <div className="flex flex-col items-center justify-center w-1/3">
-                <p className="text-white-yellow-tone text-sm -mb-4 font-sans">
+              <div className="flex flex-col w-1/2 lg:w-1/3">
+                <p className="text-white-yellow-tone text-xs font-sans -mb-3 px-2">
                   Track your enrollment?
                 </p>
                 <SecondaryButton onClick={() => setTrackEnrollmentModal(true)}>

--- a/client/src/stores/authStore.js
+++ b/client/src/stores/authStore.js
@@ -376,6 +376,42 @@ const useAuthStore = create(
         }
       },
 
+      // Validate token by making an API call
+      validateToken: async () => {
+        const token = getCookieItem('token');
+
+        if (!token) {
+          get().logout();
+          return false;
+        }
+
+        try {
+          // Make a lightweight API call to validate the token
+          // Using the /users endpoint which requires authentication
+          const response = await axios.get(
+            `${process.env.REACT_APP_API_URL}/posts`
+          );
+
+          // If the request succeeds, token is valid
+          if (response.status === 200) {
+            return true;
+          }
+        } catch (error) {
+          // If token is expired or invalid, logout
+          if (
+            error.response &&
+            (error.response.status === 401 || error.response.status === 403)
+          ) {
+            console.log('error', error);
+            console.log('Token validation failed, logging out...');
+            get().logout();
+            return false;
+          }
+          // For other errors, assume token might still be valid
+          return true;
+        }
+      },
+
       // Get user full name
       getUserFullName: () => {
         const { user } = get();

--- a/client/src/stores/createUserStore.js
+++ b/client/src/stores/createUserStore.js
@@ -4,7 +4,28 @@ import { getCookieItem } from '../utils/jwt';
 import Swal from 'sweetalert2';
 
 const useCreateUserStore = create((set, get) => ({
-    formData: {
+  formData: {
+    firstName: '',
+    middleName: '',
+    lastName: '',
+    birthdate: '',
+    role: 'student',
+    phoneNumber: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  },
+  loading: false,
+  error: null,
+
+  setFormData: (data) =>
+    set((state) => ({
+      formData: { ...state.formData, ...data },
+    })),
+
+  resetForm: () =>
+    set({
+      formData: {
         firstName: '',
         middleName: '',
         lastName: '',
@@ -14,107 +35,111 @@ const useCreateUserStore = create((set, get) => ({
         email: '',
         password: '',
         confirmPassword: '',
-    },
-    loading: false,
-    error: null,
-
-    setFormData: (data) => set((state) => ({
-        formData: { ...state.formData, ...data }
-    })),
-
-    resetForm: () => set({
-        formData: {
-            firstName: '',
-            middleName: '',
-            lastName: '',
-            birthdate: '',
-            role: 'student',
-            phoneNumber: '',
-            email: '',
-            password: '',
-            confirmPassword: '',
-        },
-        error: null
+      },
+      error: null,
     }),
 
-    clearError: () => set({ error: null }),
+  clearError: () => set({ error: null }),
 
-    validateForm: () => {
-        const { formData } = get();
+  validateForm: () => {
+    const { formData } = get();
 
-        if (!formData.firstName) return 'First Name is required';
-        if (!formData.lastName) return 'Last Name is required';
-        if (!formData.email) return 'Email is required';
-        if (!formData.phoneNumber) return 'Phone Number is required';
-        if (!formData.password) return 'Password is required';
-        if (formData.password !== formData.confirmPassword) return 'Passwords do not match';
-        if (!formData.birthdate) return 'Birthdate is required';
+    if (!formData.firstName) return 'First Name is required';
+    if (!formData.lastName) return 'Last Name is required';
+    if (!formData.email) return 'Email is required';
+    if (!formData.phoneNumber) return 'Phone Number is required';
+    if (!formData.password) return 'Password is required';
+    if (formData.password !== formData.confirmPassword)
+      return 'Passwords do not match';
+    if (!formData.birthdate) return 'Birthdate is required';
 
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(formData.email)) return 'Please enter a valid email address';
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(formData.email))
+      return 'Please enter a valid email address';
 
-        if (formData.password.length < 8) return 'Password must be at least 8 characters long';
+    if (formData.password.length < 8)
+      return 'Password must be at least 8 characters long';
 
-        return null;
-    },
+    return null;
+  },
 
-    createUser: async () => {
-        const { formData } = get();
-        const validationError = get().validateForm();
+  createUser: async () => {
+    const { formData } = get();
+    const validationError = get().validateForm();
 
-        if (validationError) {
-            set({ error: validationError });
-            return;
+    if (validationError) {
+      set({ error: validationError });
+      return;
+    }
+
+    const token = getCookieItem('token');
+
+    set({ error: null, loading: true });
+
+    try {
+      const { confirmPassword, birthdate, ...userData } = formData;
+
+      // Parse birthdate and extract month, date, year
+      let birthmonth, birthdateNum, birthyear;
+      if (birthdate) {
+        const date = new Date(birthdate);
+        birthmonth = date.getMonth() + 1; // getMonth() returns 0-11, we need 1-12
+        birthdateNum = date.getDate();
+        birthyear = date.getFullYear();
+      }
+
+      const payload = {
+        ...userData,
+        birthmonth,
+        birthdate: birthdateNum,
+        birthyear,
+      };
+
+      const response = await axiosInstance.post(
+        `${process.env.REACT_APP_API_URL}/users/create`,
+        payload,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
         }
+      );
 
-        const token = getCookieItem('token');
+      Swal.fire({
+        icon: 'success',
+        title: 'Success',
+        text: 'User created successfully!',
+      });
 
-        set({ error: null, loading: true });
+      get().resetForm();
 
-        try {
-            const { confirmPassword, ...userData } = formData;
+      return response.data;
+    } catch (error) {
+      set({
+        error:
+          error.response?.data?.message ||
+          'Failed to create user. Please try again.',
+      });
 
-            const response = await axiosInstance.post(
-                `${process.env.REACT_APP_API_URL}/users`,
-                userData,
-                {
-                    headers: {
-                        'Content-Type': 'application/json',
-                        Authorization: `Bearer ${token}`,
-                    },
-                }
-            );
+      Swal.fire({
+        icon: 'error',
+        title: 'Oops...',
+        text:
+          error.response?.data?.message ||
+          `Something went wrong! ${error.message}`,
+      });
 
-            Swal.fire({
-                icon: 'success',
-                title: 'Success',
-                text: 'User created successfully!',
-            });
+      return null;
+    } finally {
+      set({ loading: false });
+    }
+  },
 
-            get().resetForm();
-
-            return response.data;
-        } catch (error) {
-            set({
-                error: error.response?.data?.message || 'Failed to create user. Please try again.'
-            });
-
-            Swal.fire({
-                icon: 'error',
-                title: 'Oops...',
-                text: error.response?.data?.message || `Something went wrong! ${error.message}`,
-            });
-
-            return null;
-        } finally {
-            set({ loading: false });
-        }
-    },
-
-    handleInputChange: (e) => {
-        const { name, value } = e.target;
-        get().setFormData({ [name]: value });
-    },
+  handleInputChange: (e) => {
+    const { name, value } = e.target;
+    get().setFormData({ [name]: value });
+  },
 }));
 
 export default useCreateUserStore;

--- a/client/src/stores/navigationStore.js
+++ b/client/src/stores/navigationStore.js
@@ -41,6 +41,7 @@ const getNavigationConfig = (role) => {
           { path: `/${role}/coursemanagement`, label: 'Course Assignment' },
           { path: `/${role}/enrollmentperiod`, label: 'Enrollment Period' },
           { path: `/${role}/enrollmentrequests`, label: 'Enrollment Request' },
+          { path: `/${role}/schedule`, label: 'Schedule' },
         ],
       },
       grades: { path: `/${role}/grades`, label: 'Grades' },

--- a/client/src/utils/scheduleExamples.js
+++ b/client/src/utils/scheduleExamples.js
@@ -1,0 +1,181 @@
+// Example data structures for schedule events based on Prisma schema
+// This file shows how to format schedule data from the database for use in the calendar components
+
+/**
+ * Example of schedule data from the database (Prisma schema)
+ *
+ * From schema.prisma:
+ * model schedule {
+ *   id        Int
+ *   days      String      // e.g., "M,W,F" or "T,TH"
+ *   time      String      // e.g., "10:00 AM - 11:00 AM"
+ *   courseId  String?
+ *   periodId  String?
+ *   teacherId String?
+ *   course    course?
+ *   period    academic_period?
+ *   teacher   users?
+ * }
+ */
+
+/**
+ * Transform database schedule to calendar event format
+ * @param {Object} scheduleFromDB - Schedule object from database
+ * @returns {Object} - Calendar event object
+ */
+export const transformScheduleToEvent = (scheduleFromDB) => {
+  // Parse time string (assuming format "10:00 AM - 11:00 AM")
+  const [time_start, time_end] = scheduleFromDB.time
+    .split(' - ')
+    .map((t) => t.trim());
+
+  return {
+    id: scheduleFromDB.id,
+    title: scheduleFromDB.course?.name || 'Untitled Course',
+    days: scheduleFromDB.days, // Already in correct format: "M,W,F" or "T,TH"
+    time_start: time_start,
+    time_end: time_end,
+    color: generateColorForCourse(scheduleFromDB.courseId), // Custom color logic
+    courseId: scheduleFromDB.courseId,
+    periodId: scheduleFromDB.periodId,
+    teacherId: scheduleFromDB.teacherId,
+    teacher:
+      scheduleFromDB.teacher?.firstName +
+      ' ' +
+      scheduleFromDB.teacher?.lastName,
+    // Academic period date range - IMPORTANT for recurring logic
+    periodStart: scheduleFromDB.period?.startAt,
+    periodEnd: scheduleFromDB.period?.endAt,
+    periodName: scheduleFromDB.period?.periodName,
+  };
+};
+
+/**
+ * Generate a consistent color for a course
+ * @param {string} courseId - Course ID
+ * @returns {string} - Hex color
+ */
+const generateColorForCourse = (courseId) => {
+  const colors = [
+    '#FFCF00', // Yellow
+    '#0099FF', // Blue
+    '#29CC6A', // Green
+    '#FF6B6B', // Red
+    '#9B59B6', // Purple
+    '#F39C12', // Orange
+    '#1ABC9C', // Turquoise
+    '#E74C3C', // Dark Red
+  ];
+
+  // Simple hash function for consistent color assignment
+  const hash = courseId
+    ? courseId.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    : 0;
+  return colors[hash % colors.length];
+};
+
+/**
+ * Example usage with API data
+ */
+export const exampleAPIResponse = {
+  schedules: [
+    {
+      id: 1,
+      days: 'M,W',
+      time: '10:00 AM - 11:00 AM',
+      courseId: 'course_123',
+      periodId: 'period_456',
+      teacherId: 'teacher_789',
+      course: {
+        name: 'A1: Basic German Course',
+        description: 'Introduction to German language',
+      },
+      teacher: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      period: {
+        id: 'period_456',
+        periodName: 'Fall 2025',
+        batchName: 'Batch A',
+        startAt: '2025-09-01T00:00:00.000Z',
+        endAt: '2025-12-15T23:59:59.999Z',
+        status: 'ongoing',
+      },
+    },
+    {
+      id: 2,
+      days: 'T,TH',
+      time: '1:30 PM - 2:30 PM',
+      courseId: 'course_456',
+      periodId: 'period_456',
+      teacherId: 'teacher_789',
+      course: {
+        name: 'A2: Intermediate German Course',
+        description: 'Continuing German language studies',
+      },
+      teacher: {
+        firstName: 'Jane',
+        lastName: 'Smith',
+      },
+      period: {
+        id: 'period_456',
+        periodName: 'Fall 2025',
+        batchName: 'Batch A',
+        startAt: '2025-09-01T00:00:00.000Z',
+        endAt: '2025-12-15T23:59:59.999Z',
+        status: 'ongoing',
+      },
+    },
+    {
+      id: 3,
+      days: 'M,W,F',
+      time: '3:00 PM - 4:00 PM',
+      courseId: 'course_789',
+      periodId: 'period_456',
+      teacherId: 'teacher_101',
+      course: {
+        name: 'B1: Advanced German Course',
+        description: 'Advanced German language studies',
+      },
+      teacher: {
+        firstName: 'Bob',
+        lastName: 'Johnson',
+      },
+      period: {
+        id: 'period_456',
+        periodName: 'Fall 2025',
+        batchName: 'Batch A',
+        startAt: '2025-09-01T00:00:00.000Z',
+        endAt: '2025-12-15T23:59:59.999Z',
+        status: 'ongoing',
+      },
+    },
+  ],
+};
+
+/**
+ * Transform API response to calendar events
+ */
+export const transformSchedulesForCalendar = (apiResponse) => {
+  return apiResponse.schedules.map((schedule) =>
+    transformScheduleToEvent(schedule)
+  );
+};
+
+/**
+ * Example of transformed events ready for Calendar component
+ */
+export const exampleCalendarEvents =
+  transformSchedulesForCalendar(exampleAPIResponse);
+
+// Day abbreviation reference for database storage:
+// SU = Sunday
+// M = Monday
+// T = Tuesday
+// W = Wednesday
+// TH = Thursday
+// F = Friday
+// S = Saturday
+
+// Multiple days should be comma-separated: "M,W,F" or "T,TH"

--- a/client/src/utils/scheduleUtils.js
+++ b/client/src/utils/scheduleUtils.js
@@ -1,0 +1,148 @@
+// Utility functions for handling recurring schedule events
+
+// Map day abbreviations to day indices (0 = Sunday, 6 = Saturday)
+export const dayAbbreviationMap = {
+  SU: 0,
+  M: 1,
+  T: 2,
+  W: 3,
+  TH: 4,
+  F: 5,
+  S: 6,
+};
+
+/**
+ * Check if a date falls within the academic period range
+ * @param {Date} date - The date to check
+ * @param {Date|string} periodStart - Academic period start date
+ * @param {Date|string} periodEnd - Academic period end date
+ * @returns {boolean} - True if date is within period range
+ */
+export const isDateInPeriod = (date, periodStart, periodEnd) => {
+  if (!periodStart || !periodEnd) return true; // No period restrictions
+
+  const checkDate = new Date(date);
+  const startDate = new Date(periodStart);
+  const endDate = new Date(periodEnd);
+
+  // Reset times to compare dates only
+  checkDate.setHours(0, 0, 0, 0);
+  startDate.setHours(0, 0, 0, 0);
+  endDate.setHours(0, 0, 0, 0);
+
+  return checkDate >= startDate && checkDate <= endDate;
+};
+
+/**
+ * Check if an event occurs on a given day of the week
+ * @param {Object} event - Event object with a 'days' property (e.g., "M,W,F" or "T,TH")
+ * @param {number} dayOfWeek - Day of the week (0 = Sunday, 6 = Saturday)
+ * @returns {boolean} - True if the event occurs on the given day
+ */
+export const eventOccursOnDay = (event, dayOfWeek) => {
+  if (!event.days) return false;
+
+  // Parse the days string (e.g., "M,W,F" or "T,TH")
+  const eventDays = event.days.split(',').map((d) => d.trim().toUpperCase());
+
+  // Check if any of the event's days match this date's day of week
+  return eventDays.some((dayAbbr) => {
+    const mappedDay = dayAbbreviationMap[dayAbbr];
+    return mappedDay === dayOfWeek;
+  });
+};
+
+/**
+ * Filter events that occur on a specific date based on recurrence pattern and period range
+ * @param {Array} events - Array of event objects
+ * @param {Date} date - The date to filter events for
+ * @returns {Array} - Filtered array of events that occur on the given date
+ */
+export const getEventsForDate = (events, date) => {
+  const dayOfWeek = date.getDay();
+  return events.filter((event) => {
+    // Check if event occurs on this day of the week
+    const occursOnDay = eventOccursOnDay(event, dayOfWeek);
+
+    // Check if date is within academic period range
+    const withinPeriod = isDateInPeriod(
+      date,
+      event.periodStart,
+      event.periodEnd
+    );
+
+    return occursOnDay && withinPeriod;
+  });
+};
+
+/**
+ * Parse time string to hours and minutes
+ * @param {string} timeString - Time string (e.g., "10:00 AM")
+ * @returns {Object} - Object with hour and minute properties
+ */
+export const parseTime = (timeString) => {
+  const normalized = timeString.trim();
+  const isPM = normalized.toLowerCase().includes('pm');
+  const timeMatch = normalized.match(/(\d+):(\d+)/);
+
+  if (!timeMatch) return { hour: 0, minute: 0 };
+
+  let hour = parseInt(timeMatch[1], 10);
+  const minute = parseInt(timeMatch[2], 10);
+
+  // Convert to 24-hour format
+  if (isPM && hour !== 12) {
+    hour += 12;
+  } else if (!isPM && hour === 12) {
+    hour = 0;
+  }
+
+  return { hour, minute };
+};
+
+/**
+ * Convert 24-hour time format to 12-hour format for comparison
+ * @param {string} time24 - Time in 24-hour format (e.g., "14:00")
+ * @returns {string} - Time in 12-hour format (e.g., "2:00 PM")
+ */
+const convertTo12Hour = (time24) => {
+  const [hours, minutes] = time24.split(':').map(Number);
+  const period = hours >= 12 ? 'PM' : 'AM';
+  let hour12 = hours % 12;
+  if (hour12 === 0) hour12 = 12;
+  return `${hour12}:${minutes.toString().padStart(2, '0')} ${period}`;
+};
+
+/**
+ * Get events for a specific time slot and date
+ * @param {Array} events - Array of event objects
+ * @param {string} timeSlot - Time slot string (e.g., "10:00 AM")
+ * @param {Date} date - The date to get events for
+ * @returns {Array} - Filtered array of events
+ */
+export const getEventsForTimeSlot = (events, timeSlot, date) => {
+  return events.filter((event) => {
+    // Check if the event occurs on this day of the week
+    const dayOfWeek = date.getDay();
+    const dayMatches = eventOccursOnDay(event, dayOfWeek);
+
+    // Check if date is within academic period range
+    const withinPeriod = isDateInPeriod(
+      date,
+      event.periodStart,
+      event.periodEnd
+    );
+
+    if (!dayMatches || !withinPeriod) {
+      return false;
+    }
+
+    // Convert event time from 24-hour format to 12-hour format for comparison
+    const eventTime12Hour = convertTo12Hour(event.time_start);
+
+    // Check if the event's time matches this time slot
+    const timeMatches = eventTime12Hour === timeSlot;
+
+    return timeMatches;
+  });
+};


### PR DESCRIPTION
This pull request introduces two major improvements to the handling of academic periods in the scheduling system: (1) schedules now respect academic period date boundaries, ensuring events only appear within their valid terms, and (2) the frontend display of academic period status is clarified to distinguish between enrollment status and whether classes are actually ongoing. No backend or database changes are required; all improvements are implemented via frontend logic and documentation updates.

**Academic Period Boundary Enforcement:**

* Added logic and utility functions (`isDateInPeriod`) to ensure recurring events only appear within their academic period's `startAt` and `endAt` dates, preventing schedules from recurring outside valid terms. This affects event filtering in functions like `getEventsForDate()` and `getEventsForTimeSlot()`.
* Updated event transformation and mock data to include required period fields (`periodStart`, `periodEnd`, `periodName`), and updated documentation and code examples to reflect these requirements and edge cases.
* Modified relevant frontend files to support and display period-aware schedules, including updates to PropTypes, default events, and admin schedule pages.

**Academic Period Status Display Fix:**

* Refactored status calculation throughout the frontend to distinguish between "period status" (based on dates: Upcoming, Ongoing, Ended) and "enrollment status" (based on database field: open/closed). The UI now displays combined statuses such as "Ongoing (Enrollment Closed)" to avoid confusion.
* Updated badge color coding and display logic in components (`AcademicPeriodSelect.js`, `Schedule.js`, `EnrollmentPeriod.js`) and utility/store files to consistently reflect the new status logic across the app.
* Enhanced documentation to explain the new logic, provide migration notes (no migration needed), and outline testing scenarios and benefits. [[1]](diffhunk://#diff-945d103e7b466cd740b2780d778bf4cba0733a578977781574b372f0808bd114R1-R286) [[2]](diffhunk://#diff-3b4902080d2a474ded78b94844d7b4d3a14dba454f44ee4e8bbae9ee08e509c5R1-R311)